### PR TITLE
Add a COOKIE property to store the last used notes while creation, deletion, and loading notepads.

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -211,10 +211,14 @@ document.addEventListener('DOMContentLoaded', () => {
         try {
             const response = await fetchWithPin('/api/notepads');
             const data = await response.json();
-            notepadSelector.innerHTML = data.notepads
-                .map(pad => `<option value="${pad.id}">${pad.name}</option>`)
+
+            // Read the existing cookie value
+            currentNotepadId = data['note_history'];
+            
+            // Set the appropriate selector value based on the history
+            notepadSelector.innerHTML = data.notepads_list.notepads
+                .map(pad => `<option value="${pad.id}"${pad.id === currentNotepadId?'selected':''}>${pad.name}</option>`)
                 .join('');
-            return data.notepads;
         } catch (err) {
             console.error('Error loading notepads:', err);
             return [];

--- a/public/index.html
+++ b/public/index.html
@@ -36,7 +36,6 @@
                 </button>
                 <div class="select-wrapper">
                     <select id="notepad-selector">
-                        <option value="default">Default Notepad</option>
                     </select>
                     <button id="rename-notepad" class="icon-button" aria-label="Rename current notepad">
                         <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">


### PR DESCRIPTION
**Current Behavior:**
- The website always loads the *Default Page* when you reload the page.

**Future Behaviour:** 
With this feature, the website will retain the history of the last used notes. Hence, the user can open the last opened notes quickly. 

Because it is a cookie-based solution, the last used notes can be independently maintained in different devices. No more loading the DumbPad website and going back to default page.