### PR TITLE
Added markdown parsing to preview pane, download/print options, and collaboration mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ A stupid simple, no auth (unless you want it!), modern notepad application with 
 - Optional PIN protection (4-10 digits)
 - File-based storage
 - Data persistence across updates
+- Markdown Formatting
 
 ## Quick Start
 
@@ -116,6 +117,7 @@ docker run -p 3000:3000 -v "${PWD}\data:/app/data" dumbwareio/dumbpad:latest
 * 🔒 Optional PIN protection
 * 📱 Mobile-friendly interface
 * 🗂️ Multiple notepads
+* 📄 Markdown Formatting
 * ⬇️ Download notes as text files
 * 🖨️ Print functionality
 * 🔄 Real-time saving

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "cors": "^2.8.5",
         "dotenv": "^16.4.1",
         "express": "^4.18.2",
+        "marked": "^15.0.7",
         "ws": "^8.18.0"
       },
       "devDependencies": {
@@ -1137,6 +1138,18 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.12.0"
+      }
+    },
+    "node_modules/marked": {
+      "version": "15.0.7",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-15.0.7.tgz",
+      "integrity": "sha512-dgLIeKGLx5FwziAnsk4ONoGwHwGPJzselimvlVskE9XLN4Orv9u2VA3GWw/lYUqjfA0rUT/6fqKwfZJapP9BEg==",
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 18"
       }
     },
     "node_modules/math-intrinsics": {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "cors": "^2.8.5",
     "dotenv": "^16.4.1",
     "express": "^4.18.2",
+    "marked": "^15.0.7",
     "ws": "^8.18.0"
   },
   "devDependencies": {

--- a/public/collaboration.js
+++ b/public/collaboration.js
@@ -1,3 +1,5 @@
+import { marked } from '/js/marked/marked.esm.js';
+
 export class CollaborationManager {
     constructor({ userId, userColor, currentNotepadId, operationsManager, editor, onNotepadChange, onUserDisconnect, onCursorUpdate }) {
         this.userId = userId;
@@ -8,6 +10,7 @@ export class CollaborationManager {
         this.onNotepadChange = onNotepadChange;
         this.onUserDisconnect = onUserDisconnect;
         this.onCursorUpdate = onCursorUpdate;
+        this.previewPane = document.getElementById('preview-pane');
         
         this.ws = null;
         this.isReceivingUpdate = false;
@@ -155,6 +158,9 @@ export class CollaborationManager {
             // Apply the operation
             this.editor.value = this.operationsManager.applyOperation(operation, this.editor.value);
             
+            // Update the preview pane in markdown
+            this.previewPane.innerHTML = marked.parse(this.editor.value);
+
             // Adjust cursor position based on operation type and position
             let newPos = currentPos;
             let newEnd = currentEnd;

--- a/public/index.html
+++ b/public/index.html
@@ -41,6 +41,16 @@
                             <rect x="6" y="14" width="12" height="8"></rect>
                         </svg>
                     </button>
+                    <button id="preview-markdown" class="icon-button" aria-label="Toggle preview pane">
+                        <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor"
+                            stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"
+                            class="icon icon-tabler icons-tabler-outline icon-tabler-markdown">
+                            <path stroke="none" d="M0 0h24v24H0z" fill="none" />
+                            <path d="M3 5m0 2a2 2 0 0 1 2 -2h14a2 2 0 0 1 2 2v10a2 2 0 0 1 -2 2h-14a2 2 0 0 1 -2 -2z" />
+                            <path d="M7 15v-6l2 2l2 -2v6" />
+                            <path d="M14 13l2 2l2 -2m-2 2v-6" />
+                        </svg>
+                    </button>
                     <button id="delete-notepad" class="icon-button" aria-label="Delete current notepad">
                         <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
                             <path d="M3 6h18"></path>
@@ -69,8 +79,11 @@
             </button>
         </header>
         <main>
-            <div class="editor-container">
+            <div id="editor-container" class="editor-container">
                 <textarea id="editor" placeholder="Start typing your notes here..." spellcheck="true" autofocus></textarea>
+            </div>
+            <div id="preview-container" class="preview-container" style="display: none;">
+                <div id="preview-pane"></div>
             </div>
         </main>
         <div id="save-status" class="save-status"></div>
@@ -91,6 +104,17 @@
                 <div class="modal-buttons">
                     <button id="delete-cancel">Cancel</button>
                     <button id="delete-confirm" class="danger">Delete</button>
+                </div>
+            </div>
+        </div>
+        <div id="download-modal" class="modal">
+            <div class="modal-content">
+                <h2>Download Format</h2>
+                <p class="modal-message">Choose a format to download your notepad.</p>
+                <div class="modal-buttons">
+                    <button id="download-cancel">Cancel</button>
+                    <button id="download-md">Markdown (.md)</button>
+                    <button id="download-txt">Text (.txt)</button>
                 </div>
             </div>
         </div>

--- a/public/styles.css
+++ b/public/styles.css
@@ -142,6 +142,31 @@ main {
     color: #9ca3af;
 }
 
+/* Preview pane markdown styles */
+.preview-container {
+    height: calc(100vh - 160px);
+    border-radius: 12px;
+    overflow: auto; /* Changed from hidden to auto */
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+    position: relative;
+    z-index: 1;
+    background-color: var(--textarea-bg);
+}
+
+#preview-pane {
+    white-space: pre-wrap;
+    width: 100%;
+    height: 100%;
+    border: none;
+    outline: none;
+    resize: none;
+    background-color: transparent;
+    color: var(--text-color);
+    transition: background-color 0.3s, color 0.3s;
+    position: relative;
+    z-index: 1;
+}
+
 .save-status {
     position: fixed;
     bottom: 1rem;
@@ -201,6 +226,11 @@ main {
     background-color: var(--button-hover);
 }
 
+#preview-markdown.active svg {
+    stroke-width: 2.5;
+    stroke: var(--primary-color);
+}
+
 .modal {
     display: none;
     position: fixed;
@@ -258,12 +288,12 @@ main {
     transition: background-color 0.2s;
 }
 
-#rename-cancel {
+#rename-cancel, #download-cancel {
     background-color: var(--secondary-color);
     color: var(--text-color);
 }
 
-#rename-confirm {
+#rename-confirm, #download-txt, #download-md {
     background-color: var(--primary-color);
     color: white;
 }

--- a/server.js
+++ b/server.js
@@ -245,6 +245,10 @@ app.use(cookieParser());
 app.use(express.static('public', {
     index: false
 }));
+// Serve the marked library to clients
+app.use('/js/marked', express.static(
+    path.join(__dirname, 'node_modules/marked/lib')
+  ));
 
 // Main app route with PIN check
 app.get('/', (req, res) => {


### PR DESCRIPTION
#### Feature for: https://github.com/DumbWareio/DumbPad/issues/7
Liked this idea and thought i would add it here! let me know your thoughts 🙏🏻
- Added markdown parsing to preview pane, download/print options, and collaboration mode, inherit editor styles when theme toggling
- Updated readme.md
- Update 2: refactored to hidden preview-pane div element instead of injecting to editor, inherit editor styles when toggling themes, moved md parsing before cursor update so remote cursors will stay up-to-date
- conflicts with: https://github.com/DumbWareio/DumbPad/pull/36

| Change                                                                 | Notes |
| ---------------------------------------------------------------------- | ----- |
| Added "marked" npm package to parse markdown                           | Importing module with express.static in server.js to respect current architecture (should work offline)    |
| Added markdown preview button / pane to view markdown formatting        | Added stroke color and width to svg button to distinguish when on/off      |
| When markdown is on, print should show markdown formatting             | When markdown formatting is off print will show as plain text     |
| Download now shows modal to download either .md or .txt                | Thought this would be desired with the new markdown option      |
| Updated to parse markdown while collaborating  | (real-time markdown view)      |
| Inherit editor styles to preview pane (preview 2)  | To retain styling when toggling between themes      |

<details>
<summary><b>Preview 1:</b></summary>

![markdown-preview](https://github.com/user-attachments/assets/d165c981-4877-42b4-9d46-9b500d58198b)

</details>

#

<details>
<summary><b>Preview 2:</b></summary>

- updates to inherit editor styles when toggling theme
- moved parsing before cursor update to retain remote cursors
 
![markdown-preview](https://github.com/user-attachments/assets/d2ef1a5c-d75b-4f55-a201-0df946da94ce)

</details>
