### PR TITLE
Added shortcuts for notepad controls, tooltips for shortcuts, and status abstraction

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A stupid simple, no auth (unless you want it!), modern notepad application with auto-save functionality and dark mode support.
 
-![image](https://github.com/user-attachments/assets/c6a00aac-f841-48a8-b8d3-c3d5378fc7d9)
+![image](https://github.com/user-attachments/assets/ba624fc5-f5d8-4a98-b949-c0c6d2b751a8)
 
 ## Table of Contents
 - [Features](#features)
@@ -170,6 +170,7 @@ docker run -p 3000:3000 -v "${PWD}\data:/app/data" dumbwareio/dumbpad:latest
 * dotenv: Environment configuration
 * cookie-parser: Cookie handling
 * express-rate-limit: Rate limiting
+* marked: Markdown formatting
 
 
 The `data` directory contains:
@@ -185,7 +186,8 @@ The `data` directory contains:
 - Press `Ctrl+S` (or `Cmd+S` on Mac) to force save.
 - Auto-saves every 10 seconds while typing.
 - Create multiple notepads with the + button.
-- Download notepads as .txt files.
+- Download notepads as .txt or .md files.
+- Hover over notepad controls to view tooltips of keyboard shortcuts
 - If PIN protection is enabled, you'll need to enter the PIN to access the app.
 
 ## Technical Details
@@ -222,7 +224,6 @@ Made with ❤️ by DumbWare.io
 
 ## Future Features
 
-* Markdown support
 * File attachments
 
 > Got an idea? Open an issue or submit a PR

--- a/public/index.html
+++ b/public/index.html
@@ -13,45 +13,46 @@
     <div class="container">
         <header>
             <div class="notepad-controls">
-                <button id="new-notepad" class="icon-button" aria-label="Create new notepad">
-                    <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-                        <line x1="12" y1="5" x2="12" y2="19"></line>
-                        <line x1="5" y1="12" x2="19" y2="12"></line>
-                    </svg>
-                </button>
                 <div class="select-wrapper">
+                    <button id="new-notepad" class="icon-button" aria-label="Create new notepad" data-tooltip="New (ctrl+alt+n / ctrl+command+n)">
+                        <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                            <line x1="12" y1="5" x2="12" y2="19"></line>
+                            <line x1="5" y1="12" x2="19" y2="12"></line>
+                        </svg>
+                    </button>
                     <select id="notepad-selector">
                     </select>
-                    <button id="rename-notepad" class="icon-button" aria-label="Rename current notepad">
+                </div>
+                <div class="notepad-controls-wrapper">
+                    <button id="rename-notepad" class="icon-button" aria-label="Rename current notepad" data-tooltip="Rename (ctrl+alt+r / ctrl+command+r)">
                         <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
                             <path d="M17 3a2.85 2.83 0 1 1 4 4L7.5 20.5 2 22l1.5-5.5L17 3z"></path>
                         </svg>
                     </button>
-                    <button id="download-notepad" class="icon-button" aria-label="Download current notepad">
+                    <button id="download-notepad" class="icon-button" aria-label="Download current notepad" data-tooltip="Download (ctrl+alt+a / ctrl+command+a)">
                         <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
                             <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"></path>
                             <polyline points="7 10 12 15 17 10"></polyline>
                             <line x1="12" y1="15" x2="12" y2="3"></line>
                         </svg>
                     </button>
-                    <button id="print-notepad" class="icon-button" aria-label="Print current notepad">
+                    <button id="print-notepad" class="icon-button" aria-label="Print current notepad" data-tooltip="Print (ctrl+p / command+p)">
                         <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
                             <polyline points="6 9 6 2 18 2 18 9"></polyline>
                             <path d="M6 18H4a2 2 0 0 1-2-2v-5a2 2 0 0 1 2-2h16a2 2 0 0 1 2 2v5a2 2 0 0 1-2 2h-2"></path>
                             <rect x="6" y="14" width="12" height="8"></rect>
                         </svg>
                     </button>
-                    <button id="preview-markdown" class="icon-button" aria-label="Toggle preview pane">
-                        <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor"
-                            stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"
-                            class="icon icon-tabler icons-tabler-outline icon-tabler-markdown">
+                    <button id="preview-markdown" class="icon-button" aria-label="Toggle preview pane" data-tooltip="Markdown preview (ctrl+alt+m / ctrl+command+m)">
+                        <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.4"
+                            stroke-linecap="round" stroke-linejoin="round">
                             <path stroke="none" d="M0 0h24v24H0z" fill="none" />
                             <path d="M3 5m0 2a2 2 0 0 1 2 -2h14a2 2 0 0 1 2 2v10a2 2 0 0 1 -2 2h-14a2 2 0 0 1 -2 -2z" />
                             <path d="M7 15v-6l2 2l2 -2v6" />
                             <path d="M14 13l2 2l2 -2m-2 2v-6" />
                         </svg>
                     </button>
-                    <button id="delete-notepad" class="icon-button" aria-label="Delete current notepad">
+                    <button id="delete-notepad" class="icon-button" aria-label="Delete current notepad" data-tooltip="Delete (ctrl+alt+x / ctrl+command+x)">
                         <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
                             <path d="M3 6h18"></path>
                             <path d="M19 6v14c0 1-1 2-2 2H7c-1 0-2-1-2-2V6"></path>
@@ -86,7 +87,7 @@
                 <div id="preview-pane"></div>
             </div>
         </main>
-        <div id="save-status" class="save-status"></div>
+        <div id="status-container" class="status-container"></div>
         <div id="rename-modal" class="modal">
             <div class="modal-content">
                 <h2>Rename Notepad</h2>

--- a/public/status.js
+++ b/public/status.js
@@ -1,0 +1,30 @@
+export class StatusManager {
+  constructor(containerElement) {
+    this.container = containerElement;
+    this.isError = 'error';
+    this.isSuccess= 'success';
+  }
+
+  show(message, type = 'success', timeoutMs = 2000) {
+    if(type === this.isSuccess)
+      this.container.classList.add('success-status');
+    else
+      this.container.classList.add('error-status');
+
+    this.container.textContent = message;
+    this.container.classList.add('visible');
+    this.remove(timeoutMs);
+  }
+
+  remove(timeoutMs) {
+    setTimeout(() => {
+      this.clearStatus();
+    }, timeoutMs);
+  }
+
+  clearStatus() {
+    this.container.classList.remove('visible');
+    this.container.classList.remove('success-status');
+    this.container.classList.remove('error-status');
+  }
+}

--- a/public/styles.css
+++ b/public/styles.css
@@ -5,7 +5,8 @@
     --secondary-color: #e5e7eb;
     --header-bg: #f8fafc;
     --textarea-bg: #ffffff;
-    --save-status-bg: rgba(37, 99, 235, 0.1);
+    --success-status-bg: rgba(37, 99, 235, 0.1);
+    --danger-status-bg:rgba(220, 38, 38, 0.6);
     --modal-overlay: rgba(0, 0, 0, 0.5);
     --modal-bg: #ffffff;
     --button-hover: #f3f4f6;
@@ -20,7 +21,8 @@
     --secondary-color: #374151;
     --header-bg: #111111;
     --textarea-bg: #242424;
-    --save-status-bg: rgba(96, 165, 250, 0.1);
+    --success-status-bg: rgba(96, 165, 250, 0.1);
+    --danger-status-bg:rgba(220, 38, 38, 0.2);
     --modal-bg: #242424;
     --button-hover: #374151;
     --danger-color: #dc2626;
@@ -167,22 +169,29 @@ main {
     z-index: 1;
 }
 
-.save-status {
+.status-container {
     position: fixed;
     bottom: 1rem;
     left: 50%;
     transform: translateX(-50%);
     padding: 0.5rem 1rem;
     border-radius: 20px;
-    background-color: var(--save-status-bg);
-    color: var(--primary-color);
     font-size: 0.875rem;
     opacity: 0;
     transition: opacity 0.3s;
 }
 
-.save-status.visible {
+.status-container.visible {
     opacity: 1;
+}
+
+.success-status {
+    background-color: var(--success-status-bg);
+    color: var(--primary-color);
+}
+.error-status {
+    background-color: var(--danger-status-bg);
+    color: #ffffff;
 }
 
 .notepad-controls {
@@ -193,7 +202,7 @@ main {
     gap: 1rem;
 }
 
-.select-wrapper {
+.select-wrapper, .notepad-controls-wrapper {
     display: flex;
     align-items: center;
     gap: 0.5rem;
@@ -227,7 +236,6 @@ main {
 }
 
 #preview-markdown.active svg {
-    stroke-width: 2.5;
     stroke: var(--primary-color);
 }
 
@@ -448,7 +456,7 @@ main {
     transform: translateY(0);
 }
 
-@media (max-width: 768px) {
+@media (max-width: 1100px) {
     .container {
         padding: 0.5rem;
     }
@@ -479,9 +487,15 @@ main {
     #theme-toggle {
         position: static;
     }
+
+    .notepad-controls {
+        position: static;
+        width: 100%;
+        justify-content: center;
+    }
 }
 
-@media (max-width: 480px) {
+@media (max-width: 440px) {
     .pin-container {
         gap: 0.5rem;
     }
@@ -491,6 +505,17 @@ main {
         height: 40px;
         font-size: 1.125rem;
         max-width: 28px;
+    }
+
+    .notepad-controls {
+        flex-direction: column;
+        align-items: center;
+        gap: 0.75rem;
+    }
+    
+    .select-wrapper {
+        width: 100%;
+        justify-content: center;
     }
 }
 
@@ -562,3 +587,21 @@ main {
 .remote-cursor-label {
     display: none;
 } 
+
+.tooltip {
+    position: absolute;
+    background-color: var(--secondary-color);
+    color: var(--text-color);
+    padding: 5px 10px;
+    border-radius: 4px;
+    font-size: 12px;
+    visibility: hidden;
+    opacity: 0;
+    transition: opacity 0.3s;
+    z-index: 1000; /* Ensure it's above other elements */
+}
+
+.tooltip.show {
+    visibility: visible;
+    opacity: 1;
+}


### PR DESCRIPTION
**In setup for https://github.com/DumbWareio/DumbPad/issues/32**
- added shortcuts for all notepad controls
- added tooltips over notepad controls to display action and shortcut keys
- there were issues overriding the browser-reserved shortcuts (for ctrl+n, etc) so for now i updated the modifiers to be ctrl+alt or meta+alt but still retained save and print shortcuts
- let me know if you dont like the mapped shortcut keys and that can be updated @abiteman 
- see ```app.js.addShortcutEventListeners()``` - for ease of updating/adding more shortcuts in the future
~- conflicts with: https://github.com/DumbWareio/DumbPad/pull/34~

<details>
<summary>Preview:</summary>

![shortcuts-preview](https://github.com/user-attachments/assets/4fe44fb0-bd4b-44cd-9d78-3ff3af186730)

</details>

updates after merging: https://github.com/DumbWareio/DumbPad/pull/34
- semi-fix for: https://github.com/DumbWareio/DumbPad/issues/29 - updated styling/width for collapsing selector & notepad controls for overlapping text
(would eventually like to see the title and theme toggler on top inline when collapsing but will save for another day/pr)
<details>
<summary>Collapsing Preview:</summary>

![collapsing-preview](https://github.com/user-attachments/assets/e567fb0d-0d2b-4101-81e3-f0c1de03ddd2)
</details>

- preview markdown shortcuts
- preview mode status on/off
- markdown icon styling updates
- moved marked.setOptions to app.js.initializeApp
- update readme.md (image to include all notepad controls and update details)

**minor refactors:**
- added all event listeners to a respective addEventListener function to make it easier to manage/collapsible when navigating code - then all of them are called in the initializeApp function
- abstracted out status handling to it's own class (StatusManager). improved functionality of status by adding optional status types/colors and independent timeouts
- ex: ```statusManager.show('Error saving', 'error', 3000);```
- allows you to pass a message, type (which handles styling. default success), and timeout (default 2000)
- automatically removes the status via timeout so all you need to do is call ```statusManager.show()```

##

thought these additions would help for future development like status handling, adding shortcuts, and tooltips

**future thoughts:**
- update tooltips messages to show shortcut keys based on OS detection instead of hardcoded tooltips
- add more shortcuts for cycling to next notepad, search, etc
- saving the switch to next notepad shortcut for a separate time since that requires keeping track of the notepad ids and may or may not be a lot to add to this pr