### PR TITLE
Added shortcut for iterating forward and backwards shortcut for notepads

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -14,36 +14,36 @@
         <header>
             <div class="notepad-controls">
                 <div class="select-wrapper">
-                    <button id="new-notepad" class="icon-button" aria-label="Create new notepad" data-tooltip="New (ctrl+alt+n / ctrl+command+n)">
+                    <button id="new-notepad" class="icon-button" aria-label="Create new notepad" data-tooltip="New (ctrl+alt+n / ctrl+cmd+n)">
                         <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
                             <line x1="12" y1="5" x2="12" y2="19"></line>
                             <line x1="5" y1="12" x2="19" y2="12"></line>
                         </svg>
                     </button>
-                    <select id="notepad-selector">
+                    <select id="notepad-selector" data-tooltip="ctrl+alt+up/down / ctrl+cmd+up/down">
                     </select>
                 </div>
                 <div class="notepad-controls-wrapper">
-                    <button id="rename-notepad" class="icon-button" aria-label="Rename current notepad" data-tooltip="Rename (ctrl+alt+r / ctrl+command+r)">
+                    <button id="rename-notepad" class="icon-button" aria-label="Rename current notepad" data-tooltip="Rename (ctrl+alt+r / ctrl+cmd+r)">
                         <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
                             <path d="M17 3a2.85 2.83 0 1 1 4 4L7.5 20.5 2 22l1.5-5.5L17 3z"></path>
                         </svg>
                     </button>
-                    <button id="download-notepad" class="icon-button" aria-label="Download current notepad" data-tooltip="Download (ctrl+alt+a / ctrl+command+a)">
+                    <button id="download-notepad" class="icon-button" aria-label="Download current notepad" data-tooltip="Download (ctrl+alt+a / ctrl+cmd+a)">
                         <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
                             <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"></path>
                             <polyline points="7 10 12 15 17 10"></polyline>
                             <line x1="12" y1="15" x2="12" y2="3"></line>
                         </svg>
                     </button>
-                    <button id="print-notepad" class="icon-button" aria-label="Print current notepad" data-tooltip="Print (ctrl+p / command+p)">
+                    <button id="print-notepad" class="icon-button" aria-label="Print current notepad" data-tooltip="Print (ctrl+p / cmd+p)">
                         <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
                             <polyline points="6 9 6 2 18 2 18 9"></polyline>
                             <path d="M6 18H4a2 2 0 0 1-2-2v-5a2 2 0 0 1 2-2h16a2 2 0 0 1 2 2v5a2 2 0 0 1-2 2h-2"></path>
                             <rect x="6" y="14" width="12" height="8"></rect>
                         </svg>
                     </button>
-                    <button id="preview-markdown" class="icon-button" aria-label="Toggle preview pane" data-tooltip="Markdown preview (ctrl+alt+m / ctrl+command+m)">
+                    <button id="preview-markdown" class="icon-button" aria-label="Toggle preview pane" data-tooltip="Markdown preview (ctrl+alt+m / ctrl+cmd+m)">
                         <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.4"
                             stroke-linecap="round" stroke-linejoin="round">
                             <path stroke="none" d="M0 0h24v24H0z" fill="none" />
@@ -52,7 +52,7 @@
                             <path d="M14 13l2 2l2 -2m-2 2v-6" />
                         </svg>
                     </button>
-                    <button id="delete-notepad" class="icon-button" aria-label="Delete current notepad" data-tooltip="Delete (ctrl+alt+x / ctrl+command+x)">
+                    <button id="delete-notepad" class="icon-button" aria-label="Delete current notepad" data-tooltip="Delete (ctrl+alt+x / ctrl+cmd+x)">
                         <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
                             <path d="M3 6h18"></path>
                             <path d="M19 6v14c0 1-1 2-2 2H7c-1 0-2-1-2-2V6"></path>


### PR DESCRIPTION
@abiteman 
### semi-related to: https://github.com/DumbWareio/DumbPad/issues/32
- added shortcut for iterating forward and backwards through notepads (modifier + up/down)
- added relevant tooltips
- added some UX improvements:

1. modals now focus on the cancel button when they are shown so you can hit tab and enter/space to select confirm. or just enter/space for cancel
2. deleting a notepad now show the previous notepad in the list as opposed to defaulting to the main/default notepad

<details>
<summary>Shortcuts Preview:</summary>

![shortcut-preview](https://github.com/user-attachments/assets/d04b3319-e99f-4592-ad7e-ae15504e1bcd)
</details>


### dev notes: 
- created new function selectNextNotepad that reuses the logic in the 'change' event handler by triggering it in the function to persist selecting functionality
- thinking about modularizing a bit more for reuse (ex: getNextNotepadIndex and selectNotepad)