### PR TITLE
Improve responsive design better pc, tablet, mobile experience

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A stupid simple, no auth (unless you want it!), modern notepad application with auto-save functionality and dark mode support.
 
-![image](https://github.com/user-attachments/assets/ba624fc5-f5d8-4a98-b949-c0c6d2b751a8)
+![image](https://github.com/user-attachments/assets/cb29ba21-ede0-4765-98b5-4e76c7c84ac3)
 
 ## Table of Contents
 - [Features](#features)

--- a/public/index.html
+++ b/public/index.html
@@ -12,6 +12,34 @@
 <body class="light-mode">
     <div class="container">
         <header>
+            <div class="header-top">
+                <div id="header-title">
+                    <h1>DumbPad</h1>
+                </div>
+                <div class="header-right"> 
+                    <button id="search-open" class="icon-button" data-tooltip="Search (ctrl+k / cmd+k)">
+                        <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                            <path stroke="none" d="M0 0h24v24H0z" fill="none"/><path d="M10 10m-7 0a7 7 0 1 0 14 0a7 7 0 1 0 -14 0" /><path d="M21 21l-6 -6" />
+                        </svg>
+                    </button>
+                    <button id="theme-toggle" class="icon-button" aria-label="Toggle dark mode">
+                        <svg class="moon" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                            <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"></path>
+                        </svg>
+                        <svg class="sun" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                            <circle cx="12" cy="12" r="5"></circle>
+                            <line x1="12" y1="1" x2="12" y2="3"></line>
+                            <line x1="12" y1="21" x2="12" y2="23"></line>
+                            <line x1="4.22" y1="4.22" x2="5.64" y2="5.64"></line>
+                            <line x1="18.36" y1="18.36" x2="19.78" y2="19.78"></line>
+                            <line x1="1" y1="12" x2="3" y2="12"></line>
+                            <line x1="21" y1="12" x2="23" y2="12"></line>
+                            <line x1="4.22" y1="19.78" x2="5.64" y2="18.36"></line>
+                            <line x1="18.36" y1="5.64" x2="19.78" y2="4.22"></line>
+                        </svg>
+                    </button>
+                </div>
+            </div>
             <div class="notepad-controls">
                 <div class="select-wrapper">
                     <button id="new-notepad" class="icon-button" aria-label="Create new notepad" data-tooltip="New (ctrl+alt+n / ctrl+cmd+n)">
@@ -60,30 +88,6 @@
                         </svg>
                     </button>
                 </div>
-            </div>
-            <h1 id="header-title">DumbPad</h1>
-            <div class="header-right"> 
-                <button id="search-open" class="icon-button" data-tooltip="Search (ctrl+k / cmd+k)">
-                    <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-                        <path stroke="none" d="M0 0h24v24H0z" fill="none"/><path d="M10 10m-7 0a7 7 0 1 0 14 0a7 7 0 1 0 -14 0" /><path d="M21 21l-6 -6" />
-                    </svg>
-                </button>
-                <button id="theme-toggle" class="icon-button" aria-label="Toggle dark mode">
-                    <svg class="moon" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-                        <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"></path>
-                    </svg>
-                    <svg class="sun" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-                        <circle cx="12" cy="12" r="5"></circle>
-                        <line x1="12" y1="1" x2="12" y2="3"></line>
-                        <line x1="12" y1="21" x2="12" y2="23"></line>
-                        <line x1="4.22" y1="4.22" x2="5.64" y2="5.64"></line>
-                        <line x1="18.36" y1="18.36" x2="19.78" y2="19.78"></line>
-                        <line x1="1" y1="12" x2="3" y2="12"></line>
-                        <line x1="21" y1="12" x2="23" y2="12"></line>
-                        <line x1="4.22" y1="19.78" x2="5.64" y2="18.36"></line>
-                        <line x1="18.36" y1="5.64" x2="19.78" y2="4.22"></line>
-                    </svg>
-                </button>
             </div>
         </header>
         <main>

--- a/public/search.js
+++ b/public/search.js
@@ -90,7 +90,6 @@ export default class SearchManager {
   }
 
   async openNotepad(id) {
-    // this.fetchWithPin(`/open?id=${id}`);
     await this.selectNotepad(id);
     this.closeModal();
   }

--- a/public/styles.css
+++ b/public/styles.css
@@ -5,8 +5,8 @@
     --secondary-color: #e5e7eb;
     --header-bg: #f8fafc;
     --textarea-bg: #ffffff;
-    --success-status-bg: rgba(37, 99, 235, 0.1);
-    --danger-status-bg:rgba(220, 38, 38, 0.6);
+    --success-status-bg: rgba(37, 99, 235, 0.5);
+    --danger-status-bg:rgba(220, 38, 38, 0.5);
     --modal-overlay: rgba(0, 0, 0, 0.5);
     --modal-bg: #ffffff;
     --button-hover: #f3f4f6;
@@ -21,8 +21,8 @@
     --secondary-color: #374151;
     --header-bg: #111111;
     --textarea-bg: #242424;
-    --success-status-bg: rgba(96, 165, 250, 0.1);
-    --danger-status-bg:rgba(220, 38, 38, 0.2);
+    --success-status-bg: rgba(96, 165, 250, 0.5);
+    --danger-status-bg:rgba(220, 38, 38, 0.5);
     --modal-bg: #242424;
     --button-hover: #374151;
     --danger-color: #dc2626;
@@ -40,16 +40,14 @@ body {
     background-color: var(--bg-color);
     color: var(--text-color);
     transition: background-color 0.3s, color 0.3s;
-    min-height: 100vh;
 }
 
 .container {
-    max-width: 1200px;
+    max-width: 75%;
     margin: 0 auto;
     padding: 1rem;
     display: flex;
     flex-direction: column;
-    min-height: 100vh;
 }
 
 header {
@@ -60,14 +58,19 @@ header {
     background-color: var(--header-bg);
     border-radius: 12px;
     margin-bottom: 1rem;
-    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.2);
     position: relative;
 }
 
-h1 {
+#header-title {
     font-size: 1.5rem;
     font-weight: 600;
     color: var(--text-color);
+}
+
+.header-top {
+    display: flex;
+    align-items: center;
 }
 
 .header-right {
@@ -116,15 +119,6 @@ main {
     flex: 1;
 }
 
-.editor-container {
-    height: calc(100vh - 160px);
-    border-radius: 12px;
-    overflow: hidden;
-    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
-    position: relative;
-    z-index: 1;
-    background-color: var(--textarea-bg);
-}
 
 #editor {
     width: 100%;
@@ -147,17 +141,17 @@ main {
     color: #9ca3af;
 }
 
-/* Preview pane markdown styles */
-.preview-container {
-    height: calc(100vh - 160px);
+.editor-container, .preview-container {
+    height: calc(100vh - 145px);
     border-radius: 12px;
-    overflow: auto; /* Changed from hidden to auto */
-    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+    overflow: hidden;
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.2);
     position: relative;
     z-index: 1;
     background-color: var(--textarea-bg);
 }
 
+/* Preview pane markdown styles */
 #preview-pane {
     white-space: pre-wrap;
     width: 100%;
@@ -182,6 +176,7 @@ main {
     font-size: 0.875rem;
     opacity: 0;
     transition: opacity 0.3s;
+    z-index: 2000;
 }
 
 .status-container.visible {
@@ -190,7 +185,7 @@ main {
 
 .success-status {
     background-color: var(--success-status-bg);
-    color: var(--primary-color);
+    color: #ffffff;
 }
 .error-status {
     background-color: var(--danger-status-bg);
@@ -209,6 +204,7 @@ main {
     display: flex;
     align-items: center;
     gap: 0.5rem;
+    margin: 1rem, auto;
 }
 
 #notepad-selector {
@@ -460,73 +456,6 @@ main {
     transform: translateY(0);
 }
 
-@media (max-width: 1150px) {
-    .container {
-        padding: 0.5rem;
-    }
-
-    header {
-        padding: 0.75rem;
-        margin-bottom: 0.5rem;
-    }
-
-    .editor-container {
-        height: calc(100vh - 120px);
-    }
-
-    #editor {
-        padding: 1rem;
-    }
-
-    .notepad-controls {
-        position: static;
-        margin-bottom: 1rem;
-    }
-
-    header {
-        flex-direction: column;
-        gap: 1rem;
-    }
-
-    #theme-toggle {
-        position: static;
-    }
-
-    .notepad-controls {
-        position: static;
-        width: 100%;
-        justify-content: center;
-    }
-
-    .header-right {
-        position: static;
-    }
-}
-
-@media (max-width: 500px) {
-    .pin-container {
-        gap: 0.5rem;
-    }
-
-    .pin-digit {
-        width: 32px;
-        height: 40px;
-        font-size: 1.125rem;
-        max-width: 28px;
-    }
-
-    .notepad-controls {
-        flex-direction: column;
-        align-items: center;
-        gap: 0.75rem;
-    }
-    
-    .select-wrapper {
-        width: 100%;
-        justify-content: center;
-    }
-}
-
 .login-container {
     display: flex;
     align-items: center;
@@ -621,8 +550,8 @@ main {
     top: 0;
     left: 0;
     width: 100%;
-    height: 60%;
-    /* background: rgba(0, 0, 0, 0.15); */
+    height: 100%;
+    background: rgba(0, 0, 0, 0.35);
     display: flex;
     justify-content: center;
     align-items: center;
@@ -647,6 +576,8 @@ main {
     border-radius: 4px;
     background-color: var(--textarea-bg);
     color: var(--text-color);
+    font-family: monospace;
+    font-size: 1rem;
 }
 #search-results {
     list-style-type: none;
@@ -654,6 +585,8 @@ main {
     margin: 0;
     max-height: 30rem;
     overflow-y: auto;
+    font-family: monospace;
+    font-size: 1rem;
 }
 #search-results li {
     list-style-type: none;
@@ -674,4 +607,105 @@ main {
 #search-results mark {
     background: var(--primary-color);
     font-weight: bold;
+}
+
+
+@media (max-width: 1640px) {
+    .container {
+        max-width: 95%;
+        padding: 0.3rem;
+    }
+
+    header {
+        flex-direction: column;
+        gap: 0.5rem;
+        padding: 0, auto;
+        margin: 0, auto;
+    }
+
+    .header-title {
+        justify-content: center;
+    }
+
+    .header-right {
+        position: absolute;
+        float: right;
+        padding: 0;
+        margin: 0;
+    }
+    
+    .notepad-controls {
+        position: static;
+        width: 100%;
+        align-items: center;
+        justify-content: center;
+    }
+    
+    #theme-toggle {
+        position: static;
+    }
+
+    .editor-container, .preview-container {
+        /* min-height: 84vh; */
+        max-height: 85vh;
+    }
+}
+
+
+/* MOBILE */
+@media (max-width: 585px) {
+    .container {
+        max-width: 100%;
+        padding: 0, auto;
+        margin: 0, auto;
+    }
+
+    .pin-container {
+        gap: 0.5rem;
+    }
+
+    .pin-digit {
+        width: 32px;
+        height: 40px;
+        font-size: 1.125rem;
+        max-width: 28px;
+    }
+
+    .header-top {
+        flex-direction: column;
+    }
+
+    .header-right {
+        position: static;
+    }
+
+    #header-title {
+        margin-bottom: 0.25rem;
+    }
+
+    .notepad-controls {
+        flex-direction: column;
+        margin: 0, auto;
+        padding: 0, auto;
+        margin-bottom: 0;
+        row-gap: 0.1rem;
+    }
+
+    #notepad-selector {
+        margin: 0, auto;
+        padding: 0, auto;
+    }
+    
+    .select-wrapper {
+        width: 100%;
+        justify-content: center;
+        margin: 0, auto;
+        padding: 0, auto;
+    }
+
+    .editor-container, .preview-container {
+        max-height: 73vh;
+        margin: 0, auto;
+        padding: 0, auto;
+    }
 }


### PR DESCRIPTION
@abiteman honor to be a part of the team! 🙌🏻 got another one for ya to look at in case we still wanted code reviews, let me know if you saw anything you wanted to change! 

just made some tweaks to the responsive design for a better experience across devices:

<details>
<summary>Responsive Preview:</summary>

![responsive-preview](https://github.com/user-attachments/assets/3bc05f79-1f9a-46ad-ae82-d7792a490d3d)
- no more unused scrollbars on most screens
</details>

### Updates
- Adjusted height with vh and percentages to remove of the unneeded vertical and horizontal scrollbars in certain widths/viewports
- Adjusted editor height to fit the entire notepad on screen (compatible for around 910px and above: iphone pro max / galaxy ultra lines and tablets)
- (Tablet) Updated header so now the Title should be on top and the theme/search controls should be on the same line to the right (see below):
<details>
<summary>Tablet (before vs after):</summary>

**before:** 
![image](https://github.com/user-attachments/assets/bf56b74a-4159-416c-a64b-9e4b370d1496)
- lots of spacing

**after:**
- ![image](https://github.com/user-attachments/assets/0c16bb4f-fd6c-40e3-bd72-9382b04464b1)
- reduces header size and increases usable notepad space
</details>

- (Mobile) Updated header so that Title remains on top and the theme/search controls collapse below. also reduced padding & margins to increase usable space for mobile

<details>
<summary>Mobile (before vs after)</summary>

**before:**
![image](https://github.com/user-attachments/assets/958d54c8-9773-45be-8b2e-060431eff3eb)

**after:**
![image](https://github.com/user-attachments/assets/ef163a64-3438-4519-a83e-89b2c62f75a8)
</details>

- Increase z-index of status-container css to always show on screen (even at smaller screens)
<details>
<summary>Status (before vs after)</summary>

**before:**
![image](https://github.com/user-attachments/assets/49314a47-036f-44bd-a39e-d113f8aff32f)

**after:**
![image](https://github.com/user-attachments/assets/63974324-58cb-433e-8de3-c3c7ec297dc5)
</details>

- update main image on readme.md (includes search icon now)
- normalized fuzzy search font, style, and height across all devices
