### PR TITLE
Added ALLOWED_ORIGINS env variable to allow more than one origin

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,9 +8,11 @@ services:
     volumes:
       - ./data:/app/data
     environment:
+      NODE_ENV: production # required for allowed origins
       # The title shown in the web interface
       SITE_TITLE: DumbPad
       # Optional PIN protection (leave empty to disable)
       DUMBPAD_PIN: 1234
       # The base URL for the application
-      BASE_URL: http://localhost:3001 # Comment out to allow any origin
+      BASE_URL: http://localhost:3001 # Use ALLOWED_ORIGINS below to allow all origins or specify a list
+      # ALLOWED_ORIGINS: '*' # '*' to allow all OR Comma-separated list of urls: https://internalip:port,https://base.proxy.tld,https://authprovider.domain.tld

--- a/public/app.js
+++ b/public/app.js
@@ -56,14 +56,18 @@ document.addEventListener('DOMContentLoaded', () => {
     let lastSaveTime = Date.now();
     const SAVE_INTERVAL = 2000;
     let currentNotepadId = 'default';
-    let baseUrl = '';
     let previousEditorValue = editor.value;
 
     // Add credentials to all API requests
     const fetchWithPin = async (url, options = {}) => {
         options.credentials = 'same-origin';
-        const fullUrl = baseUrl ? `${baseUrl}${url}` : url;
-        return fetch(fullUrl, options);
+        try {
+            return fetch(url, options); 
+        } 
+        catch (error) {
+            console.log(error);
+            statusManager.show(error, "error");
+        }
     };
 
     // Load notepads list
@@ -782,15 +786,19 @@ document.addEventListener('DOMContentLoaded', () => {
         fetch(`/api/config`)
             .then(response => response.json())
             .then(config => {
+                if (config.error) throw new Error(config.error);
+
                 document.getElementById('page-title').textContent = `${config.siteTitle} - Simple Notes`;
                 document.getElementById('header-title').textContent = config.siteTitle;
-                baseUrl = config.baseUrl || '';
 
                 loadNotepads().then(() => {
                     loadNotes(currentNotepadId);
                 });
             })
-            .catch(err => console.error('Error loading site configuration:', err));
+            .catch(err => {
+                console.error('Error loading site configuration:', err);
+                statusManager.show(err, "error", 30000);
+            });
         
         addEventListeners();
         setupToolTips();

--- a/public/login.html
+++ b/public/login.html
@@ -30,7 +30,7 @@
         <div id="login-content">
             <div class="pin-header">
                 <h1 id="site-title">DumbPad</h1>
-                <h2>Enter PIN</h2>
+                <h2 id="pin-description">Enter PIN</h2>
             </div>
             <div id="pin-container" class="pin-container">
                 <!-- PIN inputs will be added dynamically -->
@@ -45,7 +45,6 @@
             const themeToggle = document.getElementById('theme-toggle');
             let pinDigits = [];
             let pinLength = 4;
-            let baseUrl = '';
 
             // Create PIN input boxes
             function createPinInputs(length) {
@@ -157,29 +156,33 @@
                 try {
                     // Fetch site configuration first
                     const configResponse = await fetch('/api/config');
+                    if (configResponse.status >= 400) {
+                        throw new Error(configResponse.statusText)
+                    }
                     const config = await configResponse.json();
                     document.getElementById('site-title').textContent = config.siteTitle;
                     document.getElementById('page-title').textContent = `${config.siteTitle} - Login`;
-                    baseUrl = config.baseUrl || '';
 
                     // Then check PIN requirements
                     await checkPinRequired();
                 } catch (err) {
                     console.error('Error during initialization:', err);
+                    document.getElementById("pin-description").textContent = '';
+                    pinError.textContent = err;
                 }
             };
 
             // Check if PIN is required
             const checkPinRequired = async () => {
                 try {
-                    const response = await fetch(`${baseUrl}/api/pin-required`);
+                    const response = await fetch(`/api/pin-required`);
                     const { required, length } = await response.json();
                     if (required) {
                         pinLength = length;
                         createPinInputs(length);
                         pinDigits[0].focus();
                     } else {
-                        window.location.href = `${baseUrl}/`;
+                        window.location.href = `/`;
                     }
                 } catch (err) {
                     console.error('Error checking PIN requirement:', err);
@@ -189,7 +192,7 @@
             // Verify PIN
             const verifyPin = async (pin) => {
                 try {
-                    const response = await fetch(`${baseUrl}/api/verify-pin`, {
+                    const response = await fetch(`/api/verify-pin`, {
                         method: 'POST',
                         headers: {
                             'Content-Type': 'application/json',
@@ -201,9 +204,9 @@
                     const data = await response.json();
                     if (data.success) {
                         pinError.textContent = '';
-                        window.location.href = `${baseUrl}/`;
+                        window.location.href = `/`;
                     } else {
-                        if (response.status === 429) {
+                        if (response.status === 429 || data.error) {
                             pinError.textContent = data.error;
                             setPinInputsDisabled(true);
                         } else {


### PR DESCRIPTION
@abiteman no one really asked for this 😅 but i thought this would be useful for the issues we were seeing about origin urls and to be honest i could use this since im exposing it via authentik/auth provider and needed a way to allow multiple origins when redirecting.

no worries if you thought this wasn't needed 🙏🏻

<details>
<summary>Allowed Origins Preview:</summary>

![origin-preview](https://github.com/user-attachments/assets/ef783f4b-249b-4502-a9c7-99116d1a0843)
</details>

Changes:
- origin validation is all handled via middleware for the /api route in server.js now
- with the change above, now able to remove the BASE_URL coupling in app.js and login.html
- BASE_URL is technically no longer needed as long as ALLOWED_ORIGINS is supplied but i kept base_url there so i dont break everyone's configs while still opening up the option to add more than one origin (like for my case when using an auth provider)
- now a user should be able to supply a comma-separated list or urls/domains the site can be accessed to
- (Security) added origin validation to WebSocket server as well
- added error handling to show error
- updated docker-compose to include allowed_origins (commented out) and NODE_ENV = 'production'