### PR TITLE
Import notes & Pass more env variables

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,3 +12,26 @@ SITE_TITLE=
 # Base URL Configuration
 # Set the base URL for the application, defaults to http://localhost:PORT if not set
 BASE_URL= 
+
+# Node Environment Configuration
+# Defaults to development if empty (production required for cors)
+NODE_ENV=production
+
+# Use ALLOWED_ORIGINS below to allow all origins or specify a list
+# Usage: '*' to allow all OR Comma-separated list of urls: 'http://internalip:port,https://base.proxy.tld,https://authprovider.domain.tld'
+# ALLOWED_ORIGINS: '*'
+
+# Customize pin lockout time (if empty, defaults to 15 in minutes)
+# LOCKOUT_TIME: 15
+
+# Customize pin max attempts (if empty, defaults to 5)
+# MAX_ATTEMPTS: 5
+
+# # Default 15 (in minutes)
+# LOCKOUT_TIME=15
+
+# Customize maximum age of cookies primarily used for pin verification (default 24) in hours
+# COOKIE_MAX_AGE=24
+
+# Customize age of cookie to show the last notepad opened (default 365 | max 400) in days - shows default notepad on load if expired
+# PAGE_HISTORY_COOKIE_AGE=365

--- a/README.md
+++ b/README.md
@@ -79,6 +79,10 @@ services:
       # Use ALLOWED_ORIGINS below to allow all origins or specify a list
       # Usage: '*' to allow all OR Comma-separated list of urls: 'http://internalip:port,https://base.proxy.tld,https://authprovider.domain.tld'
       # ALLOWED_ORIGINS: '*'
+      # LOCKOUT_TIME: 15 # Customize pin lockout time (if empty, defaults to 15 in minutes)
+      # MAX_ATTEMPTS: 5 # Customize pin max attempts (if empty, defaults to 5)
+      # COOKIE_MAX_AGE: 24 # Customize maximum age of cookies primarily used for pin verification (default 24) in hours
+      # PAGE_HISTORY_COOKIE_AGE: 365 # Customize age of cookie to show the last notepad opened (default 365 | max 400) in days - shows default notepad on load if expired
 ```
 
 Then run:
@@ -103,6 +107,7 @@ PORT=3000                  # Port to run the server on
 DUMBPAD_PIN=1234          # Optional PIN protection
 SITE_TITLE=DumbPad        # Custom site title
 BASE_URL=http://localhost:3000  # Base URL for the application
+NODE_ENV=production       # Defaults to development (production required for cors)
 ```
 
 3. Start the server:
@@ -129,6 +134,7 @@ docker run -p 3000:3000 -v "${PWD}\data:/app/data" dumbwareio/dumbpad:latest
 * 🔍 Fuzzy Search by name or contents
 * 🖨️ Print functionality
 * 🔄 Real-time saving
+* 💽 Add .txt files into data folder to import (requires page refresh) 
 * ⚡ Zero dependencies on client-side
 * 🛡️ Built-in security features
 * 🎨 Clean, modern interface
@@ -185,6 +191,7 @@ docker run -p 3000:3000 -v "${PWD}\data:/app/data" dumbwareio/dumbpad:latest
 The `data` directory contains:
 - `notepads.json`: List of all notepads
 - Individual `.txt` files for each notepad's content
+- Drop in .txt files to import notes (requires page refresh)
 
 ⚠️ Important: Never delete the `data` directory when updating! This is where all your notes are stored.
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,10 +12,14 @@ services:
       SITE_TITLE: DumbPad
       # Optional PIN protection (leave empty to disable)
       DUMBPAD_PIN: 1234
-      # production required for ALLOWED_ORIGINS
-      NODE_ENV: production
+      # production required for ALLOWED_ORIGINS / CORS
+      NODE_ENV: production # Defaults to development if empty
       # The base URL for the application
       BASE_URL: http://localhost:3001
-      # Use ALLOWED_ORIGINS below to allow all origins or specify a list
+      # Use ALLOWED_ORIGINS below for CORS to allow all origins or specify a list
       # Usage: '*' to allow all OR Comma-separated list of urls: 'http://internalip:port,https://base.proxy.tld,https://authprovider.domain.tld'
       # ALLOWED_ORIGINS: '*'
+      # LOCKOUT_TIME: 15 # Customize pin lockout time (if empty, defaults to 15 in minutes)
+      # MAX_ATTEMPTS: 5 # Customize pin max attempts (if empty, defaults to 5)
+      # COOKIE_MAX_AGE: 24 # Customize maximum age of cookies primarily used for pin verification (default 24) in hours
+      # PAGE_HISTORY_COOKIE_AGE: 365 # Customize age of cookie to show the last notepad opened (default 365 | max 400) in days - shows default notepad on load if expired

--- a/public/app.js
+++ b/public/app.js
@@ -304,13 +304,13 @@ document.addEventListener('DOMContentLoaded', () => {
             previewContainer.style.display = 'block';
             editorContainer.style.display = 'none';
             previewMarkdownBtn.classList.add('active');
-            statusManager.show('Markdown Preview On');
+            statusManager.show('Markdown Preview On', 'success', 700);
         } else {
             previewContainer.style.display = 'none';
             editorContainer.style.display = 'block';
             previewMarkdownBtn.classList.remove('active');
             editor.focus();
-            statusManager.show('Markdown Preview Off', 'error');
+            statusManager.show('Markdown Preview Off', 'error', 700);
         }
 
         collaborationManager.updateLocalCursor();
@@ -401,7 +401,7 @@ document.addEventListener('DOMContentLoaded', () => {
                 }));
             }
             
-            statusManager.show('Saved');
+            statusManager.show('Saved', 'success', 500);
             lastSaveTime = Date.now();
         } catch (err) {
             console.error('Error saving notes:', err);
@@ -444,11 +444,11 @@ document.addEventListener('DOMContentLoaded', () => {
                 const errorData = await response.json();
                 throw new Error(errorData.error || 'Failed to delete notepad');
             }
-            
-            await loadNotepads();
 
             // select previous notepad
-            selectNextNotepad(false);
+            await selectNextNotepad(false);
+
+            await loadNotepads();
             
             if (collaborationManager.ws && collaborationManager.ws.readyState === WebSocket.OPEN) {
                 collaborationManager.ws.send(JSON.stringify({

--- a/public/service-worker.js
+++ b/public/service-worker.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = "PWA_CACHE_V1";
+const CACHE_NAME = "DUMBPAD_PWA_CACHE_V1";
 const ASSETS_TO_CACHE = [];
 
 const preload = async () => {


### PR DESCRIPTION
@abiteman quickie ✌🏻

Feature: https://github.com/DumbWareio/DumbPad/issues/30
Fix: https://github.com/DumbWareio/DumbPad/issues/37

#### Preview:
<details>
<summary>Import Files Preview:</summary>

![import-preview](https://github.com/user-attachments/assets/a450118a-5ef8-4f77-a07c-815295532d88)
- Add/Drop in .txt files to `/data` folder
- Refresh page to see imported notepads - Opted to add to loadNotepads insteads of adding a separate refresh button
- Delete functionality unchanged and updates the notepad.json like usual
</details>


#### Updates:
- Update notepads.json on load of notepad list with new files added to the `/data` folder
- Added mapping to env vars for: `LOCKOUT_TIME`, `MAX_ATTEMPTS`, `COOKIE_MAX_AGE`, `PAGE_HISTORY_COOKIE_AGE` for more customization

#### Minor updates I wanted to add real quick 🙏🏻
- Renamed PWA cache for better distinction
- Minor updates to status times for saved and toggling markdown preview so toasts don't stack too much
- Minor restructuring to server.js
- Updated `readme.md`, `docker-compose.yml`, and `.env.example`