### PR TITLE
Refactored Settings functionality into SettingsManager

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -159,8 +159,8 @@
         <div id="settings-modal" class="modal">
             <div class="modal-content">
                 <h2>Settings</h2>
-                <label class="modal-message">Auto Save Status Interval:</label>
-                <input id="autosave-status-interval-input" class="modal-input" type="number" min="0" value="0" placeholder="Milliseconds - 0 to disable"/>
+                <label class="modal-message">Status Message Timing (ms) - Autosave:</label>
+                <input id="autosave-status-interval-input" class="modal-input" type="number" min="0" value="0" placeholder="Leave empty or 0 to disable messages"/>
                 <div class="modal-buttons">
                     <button id="settings-cancel">Cancel</button>
                     <button id="settings-reset" class="danger">Reset</button>

--- a/public/managers/settings.js
+++ b/public/managers/settings.js
@@ -2,18 +2,60 @@ export default class SettingsManager {
   constructor(storageManager) {
     this.storageManager = storageManager;
     this.SETTINGS_KEY = 'dumbpad_settings';
+    this.settingsInputAutoSaveStatusInterval = document.getElementById('autosave-status-interval-input');
   }
   
   getSettings() {
-    const currentSettings = this.storageManager.load(this.SETTINGS_KEY);
-    // console.log("Current Settings:", currentSettings);
-    return currentSettings;
+    try {
+      const currentSettings = this.storageManager.load(this.SETTINGS_KEY);
+      // console.log("Current Settings:", currentSettings);
+      return currentSettings;
+    } catch (err) {
+      console.error(err);
+      return false;
+    }
   }
 
-  saveSettings(settingsToSave) {
-    const currentSettings = this.getSettings();
-    const newSettings = { ...currentSettings, ...settingsToSave};
-    // console.log("Saving new settings:", newSettings);
-    this.storageManager.save(this.SETTINGS_KEY, newSettings);
+  saveSettings(appSettings, reset) {
+    try {
+      const settingsToSave = reset ? appSettings : this.getInputValues(appSettings);
+      this.storageManager.save(this.SETTINGS_KEY, settingsToSave);
+      // console.log("Saved new settings:", newSettings);
+    }
+    catch (err) {
+      console.error(err);
+    }
+  }
+
+  loadSettings(appSettings, reset) {
+    try {
+      let currentSettings = this.getSettings();
+  
+      if (reset || !currentSettings) { // Set to default settings
+        // Add default settings for additional settings below:
+        appSettings.saveStatusMessageInterval = 1000;
+  
+        currentSettings = appSettings;
+        this.saveSettings(currentSettings, true);
+      }
+  
+      // initialize/update values and inputs in app.js below:
+      appSettings.saveStatusMessageInterval = currentSettings.saveStatusMessageInterval;
+      this.settingsInputAutoSaveStatusInterval.value = currentSettings.saveStatusMessageInterval;
+      
+      return currentSettings;
+    }
+    catch (err) {
+      console.error(err);
+    }
+  }
+
+  getInputValues(appSettings) {
+    // Get and set values from inputs to appSettings
+    let newInterval = parseInt(this.settingsInputAutoSaveStatusInterval.value.trim());
+    if (isNaN(newInterval) || newInterval < 0) newInterval = null;
+    appSettings.saveStatusMessageInterval = newInterval;
+
+    return appSettings;
   }
 }

--- a/public/managers/toaster.js
+++ b/public/managers/toaster.js
@@ -6,7 +6,7 @@ export class ToastManager {
   }
 
   show(message, type = 'success', isStatic = false, timeoutMs = 1000) {
-    if (timeoutMs < 1) return;
+    if (!timeoutMs || timeoutMs < 1) return;
 
     const toast = document.createElement('div');
     toast.classList.add('toast');


### PR DESCRIPTION
@abiteman hey hey ✌🏻 lower priority here, just cleaning up some code

Changes:
- refactored settings code from `app.js` into `settings.js`
- update some logic to handle load, saving, and get input values for save in settings manager
- changed wording of save status message to make it more relatable: https://github.com/DumbWareio/DumbPad/issues/51
  - ![image](https://github.com/user-attachments/assets/44c53a6b-5ed3-43e3-b318-dd9a59c6054d)


<details>
<summary>Preview:</summary>

![settings-preview](https://github.com/user-attachments/assets/fe027440-1779-43f8-b7f9-20908eb14754)
</details>