### PR TITLE
Unify theme settings with login and app

### DIFF
--- a/public/Assets/styles.css
+++ b/public/Assets/styles.css
@@ -13,6 +13,8 @@
     --danger-color: #dc2626;
     --danger-hover: #ef4444;
     --code-markdown: rgba(37, 100, 235, 0.2);
+    --transition: background-color 0.3s, color 0.3s;
+    --input-element-transition: background-color 0.2s ease;
 }
 
 [data-theme="dark"] {
@@ -41,7 +43,7 @@ body {
     font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif;
     background-color: var(--bg-color);
     color: var(--text-color);
-    transition: background-color 0.3s, color 0.3s;
+    transition: var(--transition);
 }
 
 .container {
@@ -50,6 +52,7 @@ body {
     padding: 1rem;
     display: flex;
     flex-direction: column;
+    transition: var(--transition);
 }
 
 header {
@@ -87,7 +90,7 @@ header {
     padding: 0.5rem;
     color: var(--text-color);
     border-radius: 8px;
-    transition: background-color 0.2s;
+    transition: var(--input-element-transition);
     font-size: 1.5rem;
 }
 
@@ -101,19 +104,19 @@ header {
     background-color: var(--secondary-color);
 }
 
-.light-mode .moon {
+[data-theme="light"] .moon {
     display: block;
 }
 
-.light-mode .sun {
+[data-theme="light"] .sun {
     display: none;
 }
 
-.dark-mode .moon {
+[data-theme="dark"] .moon {
     display: none;
 }
 
-.dark-mode .sun {
+[data-theme="dark"] .sun {
     display: block;
 }
 
@@ -133,7 +136,7 @@ main {
     resize: none;
     background-color: transparent;
     color: var(--text-color);
-    transition: background-color 0.3s, color 0.3s;
+    transition: var(--transition);
     position: relative;
     z-index: 2;
     font-family: monospace;
@@ -244,7 +247,7 @@ code {
     display: flex;
     align-items: center;
     justify-content: center;
-    transition: background-color 0.2s;
+    transition: var(--input-element-transition);
 }
 
 .icon-button:hover {
@@ -309,7 +312,7 @@ code {
     border-radius: 6px;
     cursor: pointer;
     font-size: 0.875rem;
-    transition: background-color 0.2s;
+    transition: var(--input-element-transition);
 }
 
 #rename-cancel, #download-cancel, #settings-cancel {
@@ -355,12 +358,8 @@ code {
 }
 
 .pin-header {
-    margin-bottom: 2rem;
-}
-
-.pin-header h1 {
     color: var(--text-color);
-    font-size: 2.5rem;
+    font-size: 1.2rem;
     margin-bottom: 1rem;
     font-weight: 700;
     text-shadow: none;
@@ -371,6 +370,7 @@ code {
     opacity: 0.8;
     font-size: 1.25rem;
     font-weight: 500;
+    margin-top: 1rem;
 }
 
 .pin-container {
@@ -438,7 +438,7 @@ code {
     margin-top: 1rem;
     min-width: 120px;
     border-radius: 8px;
-    transition: background-color 0.2s ease;
+    transition: var(--input-element-transition);
 }
 
 .modal-buttons button.primary:hover {
@@ -459,7 +459,7 @@ code {
     font-size: 1rem;
     min-width: 120px;
     border-radius: 8px;
-    transition: all 0.2s ease;
+    transition: var(--input-element-transition);
 }
 
 #pin-modal .modal-buttons button.primary:hover {
@@ -500,7 +500,7 @@ code {
     padding: 0.5rem;
     color: var(--text-color);
     border-radius: 8px;
-    transition: background-color 0.2s;
+    transition: var(--input-element-transition);
 }
 
 .login-container #theme-toggle:hover {
@@ -610,7 +610,7 @@ code {
     padding: 5px;
     cursor: pointer;
     border-bottom: 0.1px solid var(--secondary-color);
-    transition: background-color 0.2s;
+    transition: var(--input-element-transition);
 }
 #search-results li:last-child {
     border-bottom: none;

--- a/public/app.js
+++ b/public/app.js
@@ -49,16 +49,6 @@ document.addEventListener('DOMContentLoaded', () => {
         saveStatusMessageInterval: 1000,
     };
 
-    // Theme handling
-    const initializeTheme = () => {
-        if (!currentTheme) {
-            currentTheme = (window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light')
-            storageManager.save(THEME_KEY, currentTheme);
-        }
-        themeToggle.innerHTML = currentTheme === 'dark' ? '<span class="sun">☀</span>' : '<span class="moon">☽</span>';
-        // document.documentElement.setAttribute('data-theme', currentTheme); // Handled in index.html
-    }
-
     const addThemeEventListeners = () => {
         // Theme toggle handler
         themeToggle.addEventListener('click', () => {
@@ -885,7 +875,6 @@ document.addEventListener('DOMContentLoaded', () => {
                 toaster.show(err, "error", true);
             });
         
-        initializeTheme();
         settingsManager.loadSettings(appSettings);
 
         addEventListeners();

--- a/public/index.html
+++ b/public/index.html
@@ -10,8 +10,12 @@
     <link rel="stylesheet" href="Assets/styles.css">
     <link rel="manifest" href="Assets/manifest.json">
     <script>
-        (function() { // Prevent theme flicker by setting theme immediately
-            const theme = JSON.parse(localStorage.getItem('dumbpad_theme')) || (window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light');
+        (function() { // Initialize theme immediately - Prevents theme flicker
+            let theme = JSON.parse(localStorage.getItem('dumbpad_theme')) 
+            if (!theme) {
+                theme = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+                localStorage.setItem('dumbpad_theme', JSON.stringify(theme));
+            } 
             document.documentElement.setAttribute('data-theme', theme);
         })();
     </script>
@@ -21,7 +25,7 @@
         <header>
             <div class="header-top">
                 <div id="header-title">
-                    <h1>DumbPad</h1>
+                    <h1 style="font-size: 1.5rem;">DumbPad</h1>
                 </div>
                 <div class="header-right"> 
                     <button id="search-open" class="icon-button" data-tooltip="Search ({shortcut})" data-shortcuts='{"win": "ctrl+k", "mac": "cmd+k"}'>

--- a/public/login.html
+++ b/public/login.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" data-theme="light">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -9,8 +9,12 @@
     <link rel="apple-touch-icon" href="Assets/dumbpad.png">
     <link rel="stylesheet" href="Assets/styles.css">
     <script>
-        (function() { // Prevent theme flicker by setting theme immediately
-            const theme = localStorage.getItem('dumbpad_theme') || (window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light');
+        (function() { // Initialize theme immediately - Prevents theme flicker
+            let theme = JSON.parse(localStorage.getItem('dumbpad_theme')) 
+            if (!theme) {
+                theme = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+                localStorage.setItem('dumbpad_theme', JSON.stringify(theme));
+            } 
             document.documentElement.setAttribute('data-theme', theme);
         })();
     </script>
@@ -49,6 +53,7 @@
             const pinContainer = document.getElementById('pin-container');
             const pinError = document.getElementById('pin-error');
             const themeToggle = document.getElementById('theme-toggle');
+            let currentTheme = JSON.parse(localStorage.getItem('dumbpad_theme'));
             let pinDigits = [];
             let pinLength = 4;
 
@@ -227,23 +232,13 @@
                 }
             };
 
-            // Initialize theme
-            const initializeTheme = () => {
-                if (localStorage.getItem('theme') === 'dark' || 
-                    (!localStorage.getItem('theme') && window.matchMedia('(prefers-color-scheme: dark)').matches)) {
-                    document.body.classList.remove('light-mode');
-                    document.body.classList.add('dark-mode');
-                }
-            };
-
             // Theme toggle handler
             const toggleTheme = () => {
-                document.body.classList.toggle('dark-mode');
-                document.body.classList.toggle('light-mode');
-                localStorage.setItem('theme', document.body.classList.contains('dark-mode') ? 'dark' : 'light');
+                currentTheme = currentTheme === 'dark' ? 'light' : 'dark';
+                document.documentElement.setAttribute('data-theme', currentTheme);
+                localStorage.setItem('dumbpad_theme', JSON.stringify(currentTheme));
             };
 
-            initializeTheme();
             themeToggle.addEventListener('click', toggleTheme);
             initialize(); // Start initialization
         });


### PR DESCRIPTION
@abiteman quick fix here to login theme settings (should've updated this in the previous pr) 🙏🏻

#### Unify login theme settings with app theme

![after-theme-preview](https://github.com/user-attachments/assets/d53d7b57-7c32-4bff-b3a7-393af6d60714)

Changes:
- Updates to reference the same local storage item for theme 
  - Previously app and login were using two different localstorage items to set the theme
  - login.js - `theme`
  - app.js - `dumbpad_theme`
- If presented with login or app, immediately set the `data-theme` based on the `dumbpad_theme` or user preferred color scheme and store to local storage
- Unify transitions for container so that `container` on login page changes theme at the same rate of `body` (previously transitioning at two different speeds showing block of the elements) 
- Set initial header-title h1 to same size in styles to reduce header size flickering on load/refresh
- Removed initializeTheme functions since we do that onload of the page now and no longer needed