### PR TITLE
Add remote delete confirmation and functionality

### DIFF
--- a/public/Assets/styles.css
+++ b/public/Assets/styles.css
@@ -626,6 +626,51 @@ code {
     font-weight: bold;
 }
 
+.settings-form {
+    margin-bottom: 1.5rem;
+}
+
+.checkbox-label {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+}
+.checkbox-label input {
+    margin-top: 0.5rem;
+}
+
+input[type="checkbox"] {
+    appearance: none;
+    -webkit-appearance: none;
+    width: 40px;
+    height: 20px;
+    background-color: #ccc;
+    border-radius: 10px;
+    position: relative;
+    cursor: pointer;
+    transition: background-color 0.3s;
+  }
+  
+  input[type="checkbox"]:after {
+    content: "";
+    position: absolute;
+    left: 2px;
+    top: 2px;
+    width: 16px;
+    height: 16px;
+    border-radius: 50%;
+    background-color: white;
+    transition: transform 0.3s;
+  }
+  
+  input[type="checkbox"]:checked {
+    background-color: var(--primary-color);
+  }
+  
+  input[type="checkbox"]:checked:after {
+    transform: translateX(20px);
+  }
+
 @media(max-width: 1400px) {
     #header-title {
         font-size: 1.2rem;

--- a/public/index.html
+++ b/public/index.html
@@ -163,8 +163,16 @@
         <div id="settings-modal" class="modal">
             <div class="modal-content">
                 <h2>Settings</h2>
-                <label class="modal-message">Status Message Timing (ms) - Autosave:</label>
-                <input id="autosave-status-interval-input" class="modal-input" type="number" min="0" value="0" placeholder="Leave empty or 0 to disable messages"/>
+                <div class="settings-form">
+                    <label class="modal-message">
+                        Status Message Timing (ms) - Autosave:
+                        <input id="autosave-status-interval-input" class="modal-input" type="number" min="0" value="0" placeholder="Leave empty or 0 to disable messages" />
+                    </label>
+                    <label class="checkbox-label">
+                        Enable Remote Connection Messages:
+                        <input type="checkbox" id="settings-remote-connection-messages" />
+                    </label>
+                </div>
                 <div class="modal-buttons">
                     <button id="settings-cancel">Cancel</button>
                     <button id="settings-reset" class="danger">Reset</button>

--- a/public/managers/confirmation.js
+++ b/public/managers/confirmation.js
@@ -1,0 +1,40 @@
+export default class ConfirmationManager {
+  constructor() {}
+
+  // Use to show confirmations when a modal is already open
+  async show(message, onConfirm, onCancel) {
+    const confirmed = window.confirm(message);
+  
+    if (confirmed) {
+      if (Array.isArray(onConfirm)) { // Check if onConfirm is an array
+        for (const func of onConfirm) {
+          if (typeof func === 'function') {
+            await func(); // Await each function call
+          } else {
+            console.log('Invalid function in onConfirm array.');
+          }
+        }
+      } else if (typeof onConfirm === 'function') {
+        await onConfirm(); // Await single function call
+      } else {
+        console.log('Confirmed, but no onConfirm function or array provided.');
+      }
+    } else {
+      if (Array.isArray(onCancel)) {
+        for (const func of onCancel) {
+          if (typeof func === 'function') {
+            await func(); // Await each function call
+          } else {
+            console.log('Invalid function in onCancel array.');
+          }
+        }
+      } else if (typeof onCancel === 'function') {
+        await onCancel(); // Await single function call
+      } else {
+        console.log('Cancelled, but no onCancel function or array provided.');
+      }
+    }
+
+    return confirmed;
+  }
+}

--- a/public/managers/settings.js
+++ b/public/managers/settings.js
@@ -3,11 +3,20 @@ export default class SettingsManager {
     this.storageManager = storageManager;
     this.SETTINGS_KEY = 'dumbpad_settings';
     this.settingsInputAutoSaveStatusInterval = document.getElementById('autosave-status-interval-input');
+    this.settingsEnableRemoteConnectionMessages = document.getElementById('settings-remote-connection-messages');
   }
   
+  defaultSettings() {
+    return { // Add additional default settings in here:
+      saveStatusMessageInterval: 500,
+      enableRemoteConnectionMessages: false,
+    }
+  }
+
   getSettings() {
     try {
-      const currentSettings = this.storageManager.load(this.SETTINGS_KEY);
+      let currentSettings = this.storageManager.load(this.SETTINGS_KEY);
+      if (!currentSettings) currentSettings = this.defaultSettings();
       // console.log("Current Settings:", currentSettings);
       return currentSettings;
     } catch (err) {
@@ -16,32 +25,32 @@ export default class SettingsManager {
     }
   }
 
-  saveSettings(appSettings, reset) {
+  saveSettings(reset) {
     try {
-      const settingsToSave = reset ? appSettings : this.getInputValues(appSettings);
+      const settingsToSave = reset ? this.defaultSettings() : this.getInputValues();
       this.storageManager.save(this.SETTINGS_KEY, settingsToSave);
       // console.log("Saved new settings:", newSettings);
+      return settingsToSave;
     }
     catch (err) {
       console.error(err);
     }
   }
 
-  loadSettings(appSettings, reset) {
+  loadSettings(reset) {
     try {
+      const appSettings = this.defaultSettings();
       let currentSettings = this.getSettings();
   
-      if (reset || !currentSettings) { // Set to default settings
-        // Add default settings for additional settings below:
-        appSettings.saveStatusMessageInterval = 1000;
-  
-        currentSettings = appSettings;
-        this.saveSettings(currentSettings, true);
-      }
+      // saves default values to local storage
+      if (reset || !currentSettings) currentSettings = this.saveSettings(true);
   
       // initialize/update values and inputs in app.js below:
       appSettings.saveStatusMessageInterval = currentSettings.saveStatusMessageInterval;
       this.settingsInputAutoSaveStatusInterval.value = currentSettings.saveStatusMessageInterval;
+
+      appSettings.enableRemoteConnectionMessages = currentSettings.enableRemoteConnectionMessages;
+      this.settingsEnableRemoteConnectionMessages.checked = currentSettings.enableRemoteConnectionMessages;
       
       return currentSettings;
     }
@@ -50,11 +59,15 @@ export default class SettingsManager {
     }
   }
 
-  getInputValues(appSettings) {
+  getInputValues() {
+    const appSettings = this.defaultSettings();
+
     // Get and set values from inputs to appSettings
     let newInterval = parseInt(this.settingsInputAutoSaveStatusInterval.value.trim());
-    if (isNaN(newInterval) || newInterval < 0) newInterval = null;
+    if (isNaN(newInterval) || newInterval <= 0) newInterval = null;
     appSettings.saveStatusMessageInterval = newInterval;
+
+    appSettings.enableRemoteConnectionMessages = this.settingsEnableRemoteConnectionMessages.checked;
 
     return appSettings;
   }

--- a/server.js
+++ b/server.js
@@ -91,6 +91,20 @@ wss.on('connection', (ws) => {
                 userId = data.userId;
                 clients.set(userId, ws);
                 console.log('User connected:', userId);
+                
+                if (clients.size > 1) {
+                    console.log('Notifying other clients about new user:', userId);
+                    clients.forEach((client, clientId) => {
+                        if (client.readyState === WebSocket.OPEN) { 
+                            client.send(JSON.stringify({
+                                type: 'user_connected',
+                                userId: userId,
+                                notepadId: data.notepadId,
+                                count: clients.size
+                            }));
+                        }
+                    })
+                }
             }
 
             // Handle different message types
@@ -199,7 +213,8 @@ wss.on('connection', (ws) => {
                 if (client.readyState === WebSocket.OPEN) {
                     client.send(JSON.stringify({
                         type: 'user_disconnected',
-                        userId: userId
+                        userId: userId,
+                        count: clients.size
                     }));
                 }
             });


### PR DESCRIPTION
@abiteman itsa me ✌🏼 some changes here for issue #53. feel free to let me know if you see anything that could be updated! 🙏🏻

<details>
<summary>Remote Delete Preview:</summary>

(Timing of the previews are off since i had to record on two different clients but the idea should be there)

| Preview | Notes |
|--------|--------|
| ![image](https://github.com/user-attachments/assets/b8ac0ba5-db48-4f4e-a593-e477ddecceea) | - prepends new message in delete modal `One or more Collaborators are connected` if one or more users are online |
| ![deletepreview](https://github.com/user-attachments/assets/c042564f-2fbb-4b43-8839-09e74da6ab02) | - remote user deleting notepad |
| ![rcdelete-preview](https://github.com/user-attachments/assets/532e8f43-e579-4d10-b028-767ff9618bab) | - confirmation of  delete. now receives confirmation of delete if on the same notepad. updates notepad list and switches to previous notepad | 

</details>

- Added logic to handle notepad selection to previous notepad after `CONFIRM` of delete
- confirmation only triggers if two users are on the same notepad

<details>
<summary>Revert Delete Preview:</summary>

(Timing of the previews are off since i had to record on two different clients but the idea should be there)

| Preview | Notes |
|--------|--------|
| ![dontdeletepreview](https://github.com/user-attachments/assets/ed12a98b-b3e8-432a-b8c8-fb14c91062a1) | - remote user `DELETE` notepad. when the other user reverts the delete this user will be notified and their notepad list is reloaded |
| ![rcdontdelete-preview](https://github.com/user-attachments/assets/43da9910-8031-4ae2-9b96-cf82f9d8835f) | - remote user `CANCEL` deletion. Reverts notepad deletion and shows message. Will then notify remote clients with a toast message of the revert |
</details>

- Logic to handle reverting delete on cancel from remote user: 
  - Show alert confirmation > Cancel
  - Save the current notepad, instead of switching
  - Reload the notepad list
  - Rename the current notepad with the notepad name before the delete
  - Reload the notepad list again
  - then show reverted toast message
  - After revert, send a revert_delete_notepad websocket message to notify the other users of this update and reload their notepads list to reshow the reverted notepad back in the list
  - wanted to use as much existing functionality without making too many changes could probably refactor more later
- One limitation: i noticed this only works when on the same domain probably because it relies on the websocket connection url - may have to take another look at this later

<details>
<summary>Added Remote Connection Statuses (preview):</summary>

![rcstatus-preview](https://github.com/user-attachments/assets/7941d78b-8199-4f25-8897-aece526751f1)
</details>

- Added new settings to enable/show remote connection messages whenever a user connects or disconnects
- default off

Other changes:
- added new `ConfirmationManager` to handle logic alert confirmations / cancels asynchronously
  - pass an array of functions to chain function calls for confirm and cancel
- add new ws message types for `notepad_delete` & `notify_delete_revert`
- global checkbox styling to toggle sliders in `styles.css`
- moved websocket connection/initialization up to create the connection immediately
- minor refactor of app.js to hoist certain functions
- minor refactor to put default appSettings (local storage) into `SettingsManager` so all logic should remain in there
