### PR TITLE
Add setting for using Markdown preview as default view

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,7 @@ docker run -p 3000:3000 -v "${PWD}\data:/app/data" dumbwareio/dumbpad:latest
 * 🎨 Clean, modern interface
 * 📦 Docker support with easy configuration
 * 🌐 Optional CORS support
+* ⚙️ Customizable settings
 
 ## Configuration
 

--- a/public/Assets/styles.css
+++ b/public/Assets/styles.css
@@ -290,9 +290,8 @@ code {
 }
 
 .modal-input {
-    width: 100%;
-    padding: 0.75rem;
-    margin-bottom: 1rem;
+    width: 75%;
+    padding: 0.5rem;
     border: 1px solid var(--secondary-color);
     border-radius: 6px;
     background-color: var(--textarea-bg);
@@ -627,15 +626,19 @@ code {
 }
 
 .settings-form {
-    margin-bottom: 1.5rem;
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+    margin-top: 1rem;
+    /* margin-bottom: 1.5rem; */
 }
 
-.checkbox-label {
+.settings-label {
     display: flex;
     flex-direction: column;
     align-items: flex-start;
 }
-.checkbox-label input {
+.settings-label input {
     margin-top: 0.5rem;
 }
 

--- a/public/app.js
+++ b/public/app.js
@@ -59,7 +59,7 @@ document.addEventListener('DOMContentLoaded', () => {
     cursorManager.DEBUG = DEBUG;
     const storageManager = new StorageManager();
     let currentTheme =  storageManager.load(THEME_KEY);
-    const settingsManager = new SettingsManager(storageManager);
+    const settingsManager = new SettingsManager(storageManager, applySettings);
     const confirmationManager = new ConfirmationManager();
 
     // Generate user ID and color
@@ -300,8 +300,10 @@ document.addEventListener('DOMContentLoaded', () => {
     }
 
     // Function to toggle between edit and preview modes
-    const toggleMarkdownPreview = () => {
-        isPreviewMode = !isPreviewMode;
+    function toggleMarkdownPreview(toggle, enable, enableStatusMessage = true) {
+        if (toggle) isPreviewMode = !isPreviewMode;
+        else isPreviewMode = enable;
+         
         if (isPreviewMode) {
             // Render and show the markdown
             inheritEditorStyles(previewPane);
@@ -309,13 +311,13 @@ document.addEventListener('DOMContentLoaded', () => {
             previewContainer.style.display = 'block';
             editorContainer.style.display = 'none';
             previewMarkdownBtn.classList.add('active');
-            toaster.show('Markdown Preview On', 'success');
+            if (enableStatusMessage) toaster.show('Markdown Preview On', 'success');
         } else {
             previewContainer.style.display = 'none';
             editorContainer.style.display = 'block';
             previewMarkdownBtn.classList.remove('active');
             editor.focus();
-            toaster.show('Markdown Preview Off', 'error');
+            if (enableStatusMessage) toaster.show('Markdown Preview Off', 'error');
         }
 
         collaborationManager.updateLocalCursor();
@@ -692,7 +694,7 @@ document.addEventListener('DOMContentLoaded', () => {
         printNotepadBtn.addEventListener('click', () => {
             printNotepad();
         });
-        previewMarkdownBtn.addEventListener('click', toggleMarkdownPreview);
+        previewMarkdownBtn.addEventListener('click', () => toggleMarkdownPreview(true));
 
         settingsButton.addEventListener('click', () => {
             settingsManager.loadSettings();
@@ -881,6 +883,10 @@ document.addEventListener('DOMContentLoaded', () => {
             });
         });
     }
+    
+    function applySettings(currentSettings) {
+        toggleMarkdownPreview(false, currentSettings.defaultMarkdownPreview, false);
+    };
 
     const searchManager = new SearchManager(fetchWithPin, selectNotepad, closeAllModals);
 
@@ -911,6 +917,8 @@ document.addEventListener('DOMContentLoaded', () => {
             breaks: true,
             gfm: true
         });
+
+        applySettings(appSettings);
 
         registerServiceWorker();
     };

--- a/public/index.html
+++ b/public/index.html
@@ -164,13 +164,17 @@
             <div class="modal-content">
                 <h2>Settings</h2>
                 <div class="settings-form">
-                    <label class="modal-message">
+                    <label class="settings-label">
                         Status Message Timing (ms) - Autosave:
                         <input id="autosave-status-interval-input" class="modal-input" type="number" min="0" value="0" placeholder="Leave empty or 0 to disable messages" />
                     </label>
-                    <label class="checkbox-label">
+                    <label class="settings-label">
                         Enable Remote Connection Messages:
                         <input type="checkbox" id="settings-remote-connection-messages" />
+                    </label>
+                    <label class="settings-label">
+                        Markdown preview as default view:
+                        <input type="checkbox" id="settings-default-markdown-preview" />
                     </label>
                 </div>
                 <div class="modal-buttons">

--- a/public/managers/settings.js
+++ b/public/managers/settings.js
@@ -1,15 +1,18 @@
 export default class SettingsManager {
-  constructor(storageManager) {
+  constructor(storageManager, applySettings) {
     this.storageManager = storageManager;
     this.SETTINGS_KEY = 'dumbpad_settings';
+    this.applySettings = applySettings
     this.settingsInputAutoSaveStatusInterval = document.getElementById('autosave-status-interval-input');
     this.settingsEnableRemoteConnectionMessages = document.getElementById('settings-remote-connection-messages');
+    this.settingsDefaultMarkdownPreview = document.getElementById('settings-default-markdown-preview');
   }
   
   defaultSettings() {
     return { // Add additional default settings in here:
       saveStatusMessageInterval: 500,
       enableRemoteConnectionMessages: false,
+      defaultMarkdownPreview: false,
     }
   }
 
@@ -30,6 +33,7 @@ export default class SettingsManager {
       const settingsToSave = reset ? this.defaultSettings() : this.getInputValues();
       this.storageManager.save(this.SETTINGS_KEY, settingsToSave);
       // console.log("Saved new settings:", newSettings);
+      this.applySettings(settingsToSave);
       return settingsToSave;
     }
     catch (err) {
@@ -51,6 +55,9 @@ export default class SettingsManager {
 
       appSettings.enableRemoteConnectionMessages = currentSettings.enableRemoteConnectionMessages;
       this.settingsEnableRemoteConnectionMessages.checked = currentSettings.enableRemoteConnectionMessages;
+
+      appSettings.defaultMarkdownPreview = currentSettings.defaultMarkdownPreview;
+      this.settingsDefaultMarkdownPreview.checked = currentSettings.defaultMarkdownPreview;
       
       return currentSettings;
     }
@@ -69,6 +76,8 @@ export default class SettingsManager {
 
     appSettings.enableRemoteConnectionMessages = this.settingsEnableRemoteConnectionMessages.checked;
 
+    appSettings.defaultMarkdownPreview = this.settingsDefaultMarkdownPreview.checked;
+    
     return appSettings;
   }
 }


### PR DESCRIPTION
@abiteman fix for setting markdown preview as default 😄

Issue: from discord chat

<details>
<summary>Preview:</summary>

![defaultmarkdown-preview](https://github.com/user-attachments/assets/91e6a2b4-8d02-4e95-a28b-ca62c098286f)
</details>

Changes:
- Add  new setting `Markdown preview as default view` in settings modal
  - on save/reset of setting this should automatically enable/disable markdown preview based on setting
  - onload we check the setting from local storage and update the markdown preview accordingly
- Minor updates to unify settings-label class for easier development when adding new settings
- Update readme.md
