### PR TITLE
v1.0.1 - Query Param support, enhance markdown previews with new styles, mirror markdown preview styles for print, new setting, service worker versioning

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,42 +1,7 @@
-/**
- * Cursor rules for maintaining code quality and consistency
- */
-
-{
-  "rules": {
-    "backend-file-header-docs": {
-      "description": "All backend source files must have a header comment explaining their purpose",
-      "pattern": "server.js",
-      "check": {
-        "type": "regex",
-        "value": "^/\\*\\*\\n \\* [^\\n]+\\n \\* [^\\n]+\\n \\* [^\\n]+\\n \\*/\\n",
-        "message": "File must start with a header comment block (3 lines) explaining its purpose"
-      }
-    },
-    "frontend-file-header-docs": {
-      "description": "All frontend source files must have a header comment explaining their purpose",
-      "pattern": "public/**/*.js",
-      "check": {
-        "type": "regex",
-        "value": "^/\\*\\*\\n \\* [^\\n]+\\n \\* [^\\n]+\\n \\* [^\\n]+\\n \\*/\\n",
-        "message": "File must start with a header comment block (3 lines) explaining its purpose"
-      }
-    },
-    "scripts-file-header-docs": {
-      "description": "All script files must have a header comment explaining their purpose",
-      "pattern": "scripts/**/*.js",
-      "check": {
-        "type": "regex",
-        "value": "^/\\*\\*\\n \\* [^\\n]+\\n \\* [^\\n]+\\n \\* [^\\n]+\\n \\*/\\n",
-        "message": "File must start with a header comment block (3 lines) explaining its purpose"
-      }
-    }
-  }
-}
-
 # Project Principles
 
 # Code Philosophy
+
 - Keep code simple, smart, and follow best practices
 - Don't over-engineer for the sake of engineering
 - Use standard conventions and patterns
@@ -47,6 +12,7 @@
 - Overcommented code is better than undercommented code
 
 # Commit Conventions
+
 - Use Conventional Commits format:
   - feat: new features
   - fix: bug fixes
@@ -61,15 +27,18 @@
 # Project Structure
 
 # Root Directory
+
 - Keep root directory clean with only essential files.
 - Contains configuration files (`docker-compose.yml`, `Dockerfile`, `.env.example`, `package.json`, `README.md`, etc.).
 - The main server entry point is `server.js`.
 
 # Backend
+
 - The core backend logic is contained in `server.js`, which handles routing, WebSocket connections, and file operations.
 - The `data/` directory is used for storing text file data.
 
 # Frontend (`public/`)
+
 - All frontend code is located in the `public/` directory.
   - `index.html`: The main application page for the text editor.
   - `login.html`: The PIN-based login page.
@@ -90,24 +59,28 @@
     - `toaster.js`: Manages the display of toast notifications for user feedback.
 
 # Scripts (`scripts/`)
+
 - This directory contains helper scripts for development and build-related tasks.
   - `cors.js`: A simple script to enable CORS, likely for development purposes.
   - `generate-png.js`: A script to generate PNG images from the SVG logo.
   - `pwa-manifest-generator.js`: A script that generates the `manifest.json` file required for PWA functionality.
 
 # Documentation
+
 - Main `README.md` in the root is the primary source of documentation.
 - Code must be self-documenting with clear naming.
 - Complex logic must include comments explaining "why" not "what".
 - JSDoc comments for public functions and APIs.
 
 # Docker Configuration
+
 - `Dockerfile` and `docker-compose.yml` in the root define the containerization setup.
 - `.dockerignore` is configured to exclude unnecessary files from the Docker image.
 - Multi-stage builds are used to keep the final image size small.
 - Use specific version tags for base images.
 
 # Code Style
+
 - Follow ESLint and Prettier configurations
 - Use meaningful variable and function names
 - Keep functions small and focused
@@ -117,6 +90,7 @@
 - Add logging when appropriate and environment variable DEBUG is set to true
 
 # Code Organization and Modularity
+
 - Break complex functionality into separate modules
 - Each module should have a single responsibility
 - Modules should be self-contained with clear interfaces
@@ -126,6 +100,7 @@
 - Group related functionality in the same directory
 
 # Theme and Styling
+
 - Maintain consistent theme colors across the application:
   - Light theme colors:
     - Background: #ffffff
@@ -142,6 +117,7 @@
 - System theme preference should be respected by default
 
 # Security and Authentication
+
 - PIN authentication logic in login.html must not be modified without verification and override from the owner
 - PIN input fields must:
   - Use type="password"

--- a/README.md
+++ b/README.md
@@ -2,9 +2,10 @@
 
 A stupid simple, no auth (unless you want it!), modern notepad application with auto-save functionality and dark mode support.
 
-![image](https://github.com/user-attachments/assets/c7138bc4-3a9f-456a-a049-67a03a2f45a5)
+![image](https://github.com/user-attachments/assets/baf945a8-327b-472a-abf9-bf03af6e7079)
 
 ## Table of Contents
+
 - [Features](#features)
 - [Quick Start](#quick-start)
   - [Prerequisites](#prerequisites)
@@ -28,16 +29,22 @@ A stupid simple, no auth (unless you want it!), modern notepad application with 
 - Optional PIN protection (4-10 digits)
 - File-based storage
 - Data persistence across updates
-- Markdown Formatting
+- Markdown Formatting with enhanced support
+  - GitHub-style alert blocks (Note, Tip, Important, Warning, Caution)
+  - Extended table formatting
+  - Auto-expand collapsible details in print (configurable)
+- Direct notepad linking with URL parameters
+- Copy shareable notepad links
+- Browser navigation support (back/forward buttons)
 - Fuzzy Search (by filename and file contents)
-- PWA Support
+- PWA Support with automatic cache updates
 
 ## Quick Start
 
 ### Prerequisites
 
-* Docker (recommended)
-* Node.js >=20.0.0 (for local development)
+- Docker (recommended)
+- Node.js >=20.0.0 (for local development)
 
 ### Option 1: Docker (For Dummies)
 
@@ -83,6 +90,7 @@ services:
 ```
 
 Then run:
+
 ```bash
 docker compose up -d
 ```
@@ -94,11 +102,13 @@ docker compose up -d
 ### Option 3: Running Locally (For Developers)
 
 1. Install dependencies:
+
 ```bash
 npm install
 ```
 
 2. Set environment variables in `.env` or `cp .env.example .env`:
+
 ```bash
 PORT=3000                  # Port to run the server on
 DUMBPAD_PIN=1234          # Optional PIN protection
@@ -107,6 +117,7 @@ BASE_URL=http://localhost:3000  # Base URL for the application
 ```
 
 3. Start the server:
+
 ```bash
 npm start
 ```
@@ -114,85 +125,121 @@ npm start
 #### Windows Users
 
 If you're using Windows PowerShell with Docker, use this format for paths:
+
 ```powershell
 docker run -p 3000:3000 -v "${PWD}\data:/app/data" dumbwareio/dumbpad:latest
 ```
 
 ## Features
 
-* 📝 Auto-saving notes
-* 🌓 Dark/Light mode support
-* 🔒 Optional PIN protection
-* 📱 Mobile-friendly interface / PWA Support
-* 🗂️ Multiple notepads
-* 📄 Markdown Formatting
-* ⬇️ Download notes as text or markdown files
-* 🔍 Fuzzy Search by name or contents
-* 🖨️ Print functionality
-* 🔄 Real-time saving
-* 💽 Add .txt files into data folder to import (requires page refresh) 
-* ⚡ Zero dependencies on client-side
-* 🛡️ Built-in security features
-* 🎨 Clean, modern interface
-* 📦 Docker support with easy configuration
-* 🌐 Optional CORS support
-* ⚙️ Customizable settings
+- 📝 Auto-saving notes
+- 🌓 Dark/Light mode support
+- 🔒 Optional PIN protection
+- 📱 Mobile-friendly interface / PWA Support
+- 🗂️ Multiple notepads
+- 📄 Enhanced Markdown Formatting with GitHub-style alerts and extended tables
+- 🔗 Direct notepad linking with shareable URLs
+- 🧭 Browser navigation support (back/forward buttons)
+- ⬇️ Download notes as text or markdown files
+- �️ Print functionality with auto-expanded collapsible sections
+- �🔍 Fuzzy Search by name or contents
+- 🔄 Real-time saving
+- 💽 Add .txt files into data folder to import (requires page refresh)
+- ⚡ Zero dependencies on client-side
+- 🛡️ Built-in security features
+- 🎨 Clean, modern interface
+- 📦 Docker support with easy configuration
+- 🌐 Optional CORS support
+- ⚙️ Customizable settings
+- 🔄 Automatic cache updates and version management
 
 ## Configuration
 
 ### Environment Variables
 
-| Variable                  | Description                                                                        | Default                     | Required |
-|---------------------------|------------------------------------------------------------------------------------|-----------------------------|----------|
-| PORT                      | Server port                                                                       | 3000                        | No       |
-| BASE_URL                  | Base URL for the application                                                      | http://localhost:PORT       | Yes      |
-| DUMBPAD_PIN               | PIN protection (4-10 digits)                                                      | None                        | No       |
-| SITE_TITLE                | Site title displayed in header                                                    | DumbPad                     | No       |
-| NODE_ENV                  | Node environment mode (development or production)                                 | production                  | No       |
-| ALLOWED_ORIGINS           | Allowed CORS origins (`*` for all or comma-separated list)                        | *                           | No       |
-| LOCKOUT_TIME              | Lockout time after max PIN attempts (in minutes)                                  | 15                          | No       |
-| MAX_ATTEMPTS              | Maximum PIN entry attempts before lockout                                         | 5                           | No       |
-| COOKIE_MAX_AGE            | Maximum age of authentication cookies (in hours)                                  | 24                          | No       |
-| PAGE_HISTORY_COOKIE_AGE   | Age of cookie storing last opened notepad (in days, max 400)                      | 365                         | No       |
+| Variable                | Description                                                  | Default               | Required |
+| ----------------------- | ------------------------------------------------------------ | --------------------- | -------- |
+| PORT                    | Server port                                                  | 3000                  | No       |
+| BASE_URL                | Base URL for the application                                 | http://localhost:PORT | Yes      |
+| DUMBPAD_PIN             | PIN protection (4-10 digits)                                 | None                  | No       |
+| SITE_TITLE              | Site title displayed in header                               | DumbPad               | No       |
+| NODE_ENV                | Node environment mode (development or production)            | production            | No       |
+| ALLOWED_ORIGINS         | Allowed CORS origins (`*` for all or comma-separated list)   | \*                    | No       |
+| LOCKOUT_TIME            | Lockout time after max PIN attempts (in minutes)             | 15                    | No       |
+| MAX_ATTEMPTS            | Maximum PIN entry attempts before lockout                    | 5                     | No       |
+| COOKIE_MAX_AGE          | Maximum age of authentication cookies (in hours)             | 24                    | No       |
+| PAGE_HISTORY_COOKIE_AGE | Age of cookie storing last opened notepad (in days, max 400) | 365                   | No       |
 
 ## Security
 
 ### Features
 
-* Variable-length PIN support (4-10 digits)
-* Constant-time PIN comparison
-* Brute force protection:
-  * 5 attempts maximum
-  * 15-minute lockout after failed attempts
-  * IP-based tracking
-* Secure cookie handling
-* No client-side PIN storage
-* Rate limiting
-* Collaborative editing
-* CORS support for origin restrictions (optional)
+- Variable-length PIN support (4-10 digits)
+- Constant-time PIN comparison
+- Brute force protection:
+  - 5 attempts maximum
+  - 15-minute lockout after failed attempts
+  - IP-based tracking
+- Secure cookie handling
+- No client-side PIN storage
+- Rate limiting
+- Collaborative editing
+- CORS support for origin restrictions (optional)
+
+## User Settings
+
+Access settings via the gear icon (⚙️) in the header or use keyboard shortcut:
+
+- **Windows/Linux**: `Ctrl+Alt+,`
+- **macOS**: `Cmd+Ctrl+,`
+
+### Available Settings
+
+| Setting                        | Description                                              | Default  | Options                   |
+| ------------------------------ | -------------------------------------------------------- | -------- | ------------------------- |
+| **Auto-save Status Interval**  | Time interval for auto-save notifications (0 = disabled) | 1000ms   | Any number (milliseconds) |
+| **Remote Connection Messages** | Show notifications when users connect/disconnect         | Enabled  | Enabled/Disabled          |
+| **Disable Print Expansion**    | Prevent auto-expanding collapsed sections when printing  | Disabled | Enabled/Disabled          |
+| **Default Markdown Preview**   | Start in markdown preview mode by default                | Disabled | Enabled/Disabled          |
+
+### Notepad Management
+
+- **Unique Names**: Notepad names are automatically made unique by the server. If you try to create or rename a notepad with an existing name, the server will append a suffix (e.g., "Note-1", "Note-2")
+- **Name Validation**: The server handles all name validation and uniqueness checks. The frontend will display a notification if your requested name was modified
+- **Auto-save**: Changes are automatically saved every 300ms after you stop typing, with periodic saves every 2 seconds
+- **Persistence**: All settings are stored in your browser's local storage and persist across sessions
 
 ## Technical Details
 
 ### Stack
 
-* **Backend**: Node.js (>=20.0.0) with Express
-* **Frontend**: Vanilla JavaScript (ES6+)
-* **Container**: Docker with multi-stage builds
-* **Security**: Express security middleware
-* **Storage**: File-based with auto-save
-* **Theme**: Dynamic dark/light mode with system preference support
+- **Backend**: Node.js (>=20.0.0) with Express
+- **Frontend**: Vanilla JavaScript (ES6+) with enhanced markdown support
+- **Container**: Docker with multi-stage builds
+- **Security**: Express security middleware
+- **Storage**: File-based with auto-save
+- **Theme**: Dynamic dark/light mode with system preference support
+- **PWA**: Service Worker with automatic cache updates and version management
+- **Markdown**: Enhanced with alert blocks, extended tables, and collapsible content
+- **Real-time**: WebSocket-based collaboration and live updates
+- **Navigation**: SPA-style routing with shareable URLs and browser history support
+- **Print**: Advanced print preview with auto-expanding collapsible content and theme preservation
 
 ### Dependencies
 
-* express: Web framework
-* cors: Cross-origin resource sharing
-* dotenv: Environment configuration
-* cookie-parser: Cookie handling
-* express-rate-limit: Rate limiting
-* marked: Markdown formatting
-* fuse.js: Fuzzy searching
+- express: Web framework
+- cors: Cross-origin resource sharing
+- dotenv: Environment configuration
+- cookie-parser: Cookie handling
+- express-rate-limit: Rate limiting
+- marked: Markdown formatting
+- marked-alert: GitHub-style alert blocks for markdown
+- marked-extended-tables: Enhanced table support for markdown
+- fuse.js: Fuzzy searching
+- ws: WebSocket support for real-time collaboration
 
 The `data` directory contains:
+
 - `notepads.json`: List of all notepads
 - Individual `.txt` files for each notepad's content
 - Drop in .txt files to import notes (requires page refresh)
@@ -201,15 +248,66 @@ The `data` directory contains:
 
 ## Usage
 
-- Just start typing! Your notes will be automatically saved.
-- Use the theme toggle in the top-right corner to switch between light and dark mode.
-- Press `Ctrl+S` (or `Cmd+S` on Mac) to force save.
-- Auto-saves every 10 seconds while typing.
-- Create multiple notepads with the + button.
-- Download notepads as .txt or .md files.
-- Hover over notepad controls to view tooltips of keyboard shortcuts
-- Press `Ctrl+K` (or `Cmd+K`) to open fuzzy search
-- If PIN protection is enabled, you'll need to enter the PIN to access the app.
+### Basic Operations
+
+- **Start typing**: Notes auto-save as you type (every 300ms after stopping, with periodic saves every 2 seconds)
+- **Theme toggle**: Switch between light/dark mode with the toggle button
+- **Force save**: `Ctrl+S` (or `Cmd+S` on Mac)
+- **Search**: `Ctrl+K` (or `Cmd+K`) to open fuzzy search across all notepads
+- **Copy link**: Click the link button (🔗) to copy the current notepad's shareable URL
+- **Settings**: Click the gear icon (⚙️) or use `Ctrl+Alt+,` (or `Cmd+Ctrl+,`)
+
+### Notepad Management
+
+- **Create**: Click the + button or `Ctrl+Alt+N` (or `Cmd+Ctrl+N`)
+- **Rename**: Click rename button or `Ctrl+Alt+R` (or `Cmd+Ctrl+R`)
+- **Delete**: Click delete button or `Ctrl+Alt+X` (or `Cmd+Ctrl+X`)
+- **Navigate**: Use dropdown, arrow keys (`Ctrl+Alt+↑/↓`), or browser back/forward buttons
+- **Download**: Click download button or `Ctrl+Alt+A` (or `Cmd+Ctrl+A`) for .txt/.md export
+- **Print**: `Ctrl+P` (or `Cmd+P`) with enhanced formatting and auto-expanded collapsible sections
+
+### Markdown Enhancements
+
+DumbPad now supports enhanced markdown features:
+
+#### GitHub-Style Alert Blocks
+
+```markdown
+> [!NOTE]
+> This is a note alert block
+
+> [!TIP]
+> This is a tip alert block
+
+> [!IMPORTANT]
+> This is an important alert block
+
+> [!WARNING]
+> This is a warning alert block
+
+> [!CAUTION]
+> This is a caution alert block
+```
+
+#### Extended Table Support
+
+- Advanced table formatting with alignment
+- Enhanced styling for better readability
+
+#### Collapsible Details
+
+```markdown
+<details>
+<summary>Click to expand</summary>
+Content that will be automatically expanded when printing
+</details>
+```
+
+### URL Parameters
+
+- **Direct notepad linking**: `?id=notepadname` - Opens a specific notepad by name (case-insensitive)
+- **Browser navigation**: Use back/forward buttons to navigate between notepads
+- **Shareable URLs**: Copy links to share specific notepads with others
 
 ## Technical Details
 
@@ -239,6 +337,7 @@ See Development Guide for local setup and guidelines.
 Made with ❤️ by DumbWare.io
 
 ## 🌐 Check Us Out
+
 - **Website:** [dumbware.io](https://www.dumbware.io/)
 - **Join the Chaos:** [Discord](https://discord.gg/zJutzxWyq2) 💬
 
@@ -250,6 +349,7 @@ Made with ❤️ by DumbWare.io
 
 ## Future Features
 
-* File attachments
+- File attachments
+- Markdown code syntax highlighting
 
 > Got an idea? Open an issue or submit a PR

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dumbpad",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dumbpad",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "dependencies": {
         "cookie-parser": "^1.4.7",
         "cors": "^2.8.5",
@@ -14,6 +14,8 @@
         "express": "^5.1.0",
         "fuse.js": "^7.1.0",
         "marked": "^15.0.11",
+        "marked-alert": "^2.1.2",
+        "marked-extended-tables": "^2.0.1",
         "ws": "^8.18.2"
       },
       "devDependencies": {
@@ -480,9 +482,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -717,9 +719,9 @@
       }
     },
     "node_modules/dotenv": {
-      "version": "16.5.0",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.5.0.tgz",
-      "integrity": "sha512-m/C+AwOAr9/W1UOIZUo232ejMNnJAJtYQjUbHoNTBNTJSvqzzDh7vnrei3o3r3m9blf6ZoDkvcw0VmozNRFJxg==",
+      "version": "16.6.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
+      "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=12"
@@ -1046,6 +1048,15 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/http-errors/node_modules/statuses": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
+      "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/iconv-lite": {
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
@@ -1140,15 +1151,33 @@
       "license": "MIT"
     },
     "node_modules/marked": {
-      "version": "15.0.11",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-15.0.11.tgz",
-      "integrity": "sha512-1BEXAU2euRCG3xwgLVT1y0xbJEld1XOrmRJpUwRCcy7rxhSCwMrmEu9LXoPhHSCJG41V7YcQ2mjKRr5BA3ITIA==",
+      "version": "15.0.12",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-15.0.12.tgz",
+      "integrity": "sha512-8dD6FusOQSrpv9Z1rdNMdlSgQOIP880DHqnohobOmYLElGEqAL/JvxvuxZO16r4HtjTlfPRDC1hbvxC9dPN2nA==",
       "license": "MIT",
       "bin": {
         "marked": "bin/marked.js"
       },
       "engines": {
         "node": ">= 18"
+      }
+    },
+    "node_modules/marked-alert": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/marked-alert/-/marked-alert-2.1.2.tgz",
+      "integrity": "sha512-EFNRZ08d8L/iEIPLTlQMDjvwIsj03gxWCczYTht6DCiHJIZhMk4NK5gtPY9UqAYb09eV5VGT+jD4lp396E0I+w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "marked": ">=7.0.0"
+      }
+    },
+    "node_modules/marked-extended-tables": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/marked-extended-tables/-/marked-extended-tables-2.0.1.tgz",
+      "integrity": "sha512-DV4Si978ZdaFbycIxzG4TdaNMtC0J8QfIKj1UOCejgJHwVjVJse8DNdJriWDeo/n74DWVYpRC6S56AdgWDPrPA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "marked": ">=3 <16"
       }
     },
     "node_modules/math-intrinsics": {
@@ -1648,9 +1677,9 @@
       }
     },
     "node_modules/statuses": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
-      "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
@@ -1755,9 +1784,9 @@
       "license": "ISC"
     },
     "node_modules/ws": {
-      "version": "8.18.2",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.2.tgz",
-      "integrity": "sha512-DMricUmwGZUVr++AEAe2uiVM7UoO9MAVZMDu05UQOaUII0lp+zOzLLU4Xqh/JvTqklB1T4uELaaPBKyjE1r4fQ==",
+      "version": "8.18.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
+      "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dumbpad",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "A simple notepad application",
   "main": "server.js",
   "scripts": {
@@ -15,6 +15,8 @@
     "express": "^5.1.0",
     "fuse.js": "^7.1.0",
     "marked": "^15.0.11",
+    "marked-alert": "^2.1.2",
+    "marked-extended-tables": "^2.0.1",
     "ws": "^8.18.2"
   },
   "devDependencies": {

--- a/public/Assets/preview-styles.css
+++ b/public/Assets/preview-styles.css
@@ -1,0 +1,323 @@
+/* Markdown styles for DumbPad */
+/* Preview pane markdown styles */
+.preview-container {
+  overflow: auto;
+}
+#preview-pane {
+  /* white-space: pre-wrap; */
+  font-family: sans-serif;
+}
+
+/* Image sizing in markdown preview */
+#preview-pane img {
+  max-width: 100%;
+  height: auto;
+  border-radius: 6px;
+}
+
+/* Link styling in markdown preview */
+#preview-pane a {
+  color: var(--primary-color);
+  text-decoration: underline;
+}
+
+#preview-pane a:hover {
+  color: var(--primary-color);
+  opacity: 0.7;
+}
+
+code {
+  background-color: var(--code-markdown);
+  padding: 2px 4px;
+  border-radius: 5px;
+  margin: 1.5rem 0;
+}
+
+/* Code block styling */
+#preview-pane pre {
+  background-color: var(--code-markdown);
+  border-radius: 8px;
+  padding: 0.5rem 3rem 0.5rem 1rem;
+  overflow-x: hidden;
+  width: fit-content;
+  max-width: 100%;
+  box-sizing: border-box;
+  position: relative;
+  margin: 1.5rem 0;
+}
+
+/* Copy button for code blocks */
+#preview-pane pre .copy-button {
+  position: absolute;
+  top: 8px;
+  right: 8px;
+  background-color: var(--secondary-color);
+  border: 1px solid var(--text-color);
+  border-radius: 4px;
+  padding: 4px;
+  width: 24px;
+  height: 24px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--text-color);
+  cursor: pointer;
+  opacity: 0.7;
+  transition: opacity 0.2s, background-color 0.2s;
+  z-index: 10;
+}
+
+#preview-pane pre .copy-button:hover {
+  opacity: 1;
+  background-color: var(--primary-color);
+  color: white;
+}
+
+#preview-pane pre .copy-button:active {
+  transform: scale(0.95);
+}
+
+#preview-pane pre code {
+  background-color: transparent;
+  padding: 0;
+  border-radius: 0;
+  font-family: "Consolas", "Monaco", "Courier New", monospace;
+  font-size: 0.9em;
+  line-height: 1.4;
+  white-space: pre-wrap;
+  max-width: 100%;
+  word-break: break-word;
+}
+
+/* Reduce spacing below headers */
+#preview-pane h1,
+#preview-pane h2,
+#preview-pane h3,
+#preview-pane h4,
+#preview-pane h5,
+#preview-pane h6 {
+  margin-top: 1em;
+  margin-bottom: 0.5em;
+  line-height: 1;
+}
+
+/* First header has no top margin */
+#preview-pane h1:first-child,
+#preview-pane h2:first-child,
+#preview-pane h3:first-child,
+#preview-pane h4:first-child,
+#preview-pane h5:first-child,
+#preview-pane h6:first-child {
+  margin-top: 0;
+}
+
+/* Markdown checkbox styling in preview pane */
+#preview-pane input[type="checkbox"] {
+  appearance: none;
+  -webkit-appearance: none;
+  width: 18px;
+  height: 18px;
+  background-color: var(--textarea-bg);
+  border: 2px solid var(--secondary-color);
+  border-radius: 3px;
+  position: relative;
+  cursor: not-allowed;
+  margin-right: 8px;
+  vertical-align: middle;
+}
+#preview-pane input[type="checkbox"]:checked {
+  background-color: var(--primary-color);
+  border-color: var(--primary-color);
+}
+#preview-pane input[type="checkbox"]:checked:after {
+  content: "✔";
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  color: white;
+  font-size: 12px;
+  font-weight: bold;
+}
+
+/* Support for browsers that don't support :has() */
+#preview-pane ul li input[type="checkbox"] {
+  margin-left: -20px;
+}
+#preview-pane ul li:has(input[type="checkbox"]) {
+  list-style: none;
+}
+/* Fallback for older browsers */
+#preview-pane ul {
+  padding-left: 20px;
+}
+#preview-pane ul li {
+  list-style: disc;
+}
+#preview-pane ul li input[type="checkbox"] + * {
+  margin-left: 4px;
+}
+/* Reduce spacing between list items */
+#preview-pane ul li,
+#preview-pane ol li {
+  margin: 0;
+  padding: 0;
+  line-height: 1.4em;
+}
+#preview-pane ul,
+#preview-pane ol {
+  padding-left: 20px;
+}
+
+/* Table styling for markdown preview */
+#preview-pane table {
+  /* border-collapse: collapse; */
+  border-spacing: 0;
+  max-width: 100%;
+  margin: 1.5rem 0;
+  font-size: 0.9em;
+  background-color: var(--textarea-bg);
+  border: 1px solid var(--secondary-color);
+  border-radius: 6px;
+  overflow: hidden;
+}
+
+#preview-pane table th,
+#preview-pane table td {
+  padding: 8px 12px;
+  text-align: left;
+  border-bottom: 1px solid var(--secondary-color);
+  border-right: 1px solid var(--secondary-color);
+  vertical-align: top;
+}
+
+#preview-pane table th:last-child,
+#preview-pane table td:last-child {
+  border-right: none;
+}
+#preview-pane table tr:last-child td {
+  border-bottom: none;
+}
+
+#preview-pane table th {
+  background-color: var(--secondary-color);
+  font-weight: 600;
+  color: var(--text-color);
+}
+
+#preview-pane table tbody tr:hover {
+  background-color: rgba(var(--primary-color), 0.05);
+}
+
+/* Table alignment classes for extended tables */
+#preview-pane table th[align="left"],
+#preview-pane table td[align="left"] {
+  text-align: left;
+}
+
+#preview-pane table th[align="center"],
+#preview-pane table td[align="center"] {
+  text-align: center;
+}
+
+#preview-pane table th[align="right"],
+#preview-pane table td[align="right"] {
+  text-align: right;
+}
+
+/* GitHub-style Alert/Callout styling */
+#preview-pane .markdown-alert {
+  padding: 0.5rem;
+  margin: 1.5rem 0;
+  color: inherit;
+  border-left: 4px solid var(--secondary-color);
+  border-radius: 6px;
+  background-color: rgba(var(--secondary-color), 0.1);
+}
+
+#preview-pane .markdown-alert-title {
+  display: flex;
+  align-items: center;
+  font-weight: 600;
+  margin-bottom: 0.5rem;
+  font-size: 0.9em;
+}
+
+#preview-pane .markdown-alert-title svg {
+  margin-right: 8px;
+  flex-shrink: 0;
+}
+
+#preview-pane .markdown-alert p:last-child {
+  margin-bottom: 0.5rem;
+}
+
+/* Alert type-specific colors */
+#preview-pane .markdown-alert-note {
+  border-left-color: #0969da;
+  background-color: rgba(9, 105, 218, 0.1);
+  padding-left: 1rem;
+}
+#preview-pane .markdown-alert-note .markdown-alert-title {
+  color: #0969da;
+}
+#preview-pane .markdown-alert-note .markdown-alert-title svg {
+  fill: #0969da;
+}
+
+#preview-pane .markdown-alert-tip {
+  border-left-color: #1f883d;
+  background-color: rgba(31, 136, 61, 0.1);
+  padding-left: 1rem;
+}
+#preview-pane .markdown-alert-tip .markdown-alert-title {
+  color: #1f883d;
+}
+#preview-pane .markdown-alert-tip .markdown-alert-title svg {
+  fill: #1f883d;
+}
+
+#preview-pane .markdown-alert-important {
+  border-left-color: #8250df;
+  background-color: rgba(130, 80, 223, 0.1);
+  padding-left: 1rem;
+}
+#preview-pane .markdown-alert-important .markdown-alert-title {
+  color: #8250df;
+}
+#preview-pane .markdown-alert-important .markdown-alert-title svg {
+  fill: #8250df;
+}
+
+#preview-pane .markdown-alert-warning {
+  border-left-color: #9e6a02;
+  background-color: rgba(158, 106, 2, 0.1);
+  padding-left: 1rem;
+}
+#preview-pane .markdown-alert-warning .markdown-alert-title {
+  color: #9e6a02;
+}
+#preview-pane .markdown-alert-warning .markdown-alert-title svg {
+  fill: #9e6a02;
+}
+
+#preview-pane .markdown-alert-caution {
+  border-left-color: #d1242f;
+  background-color: rgba(209, 36, 47, 0.1);
+  padding-left: 1rem;
+}
+#preview-pane .markdown-alert-caution .markdown-alert-title {
+  color: #d1242f;
+}
+#preview-pane .markdown-alert-caution .markdown-alert-title svg {
+  fill: #d1242f;
+}
+
+#preview-pane details {
+  background-color: var(--textarea-bg);
+  border: 1.5px solid var(--secondary-color);
+  border-radius: 6px;
+  padding: 0.5rem;
+  margin: 1.5rem 0;
+  max-width: 100%;
+}

--- a/public/Assets/styles.css
+++ b/public/Assets/styles.css
@@ -187,21 +187,6 @@ main {
     background-color: var(--textarea-bg);
 }
 
-/* Preview pane markdown styles */
-.preview-container {
-    overflow: auto;
-}
-#preview-pane {
-    white-space: pre-wrap;
-    font-family: sans-serif;
-}
-
-code {
-    background-color: var(--code-markdown);
-    padding: 2px 4px;
-    border-radius: 5px;
-}
-
 .toast-container {
     position: fixed;
     bottom: 1rem;
@@ -674,7 +659,7 @@ code {
     margin-top: 0.5rem;
 }
 
-input[type="checkbox"] {
+#settings-modal input[type="checkbox"] {
     appearance: none;
     -webkit-appearance: none;
     width: 40px;
@@ -684,9 +669,8 @@ input[type="checkbox"] {
     position: relative;
     cursor: pointer;
     transition: background-color 0.3s;
-  }
-  
-  input[type="checkbox"]:after {
+}
+#settings-modal input[type="checkbox"]:after {
     content: "";
     position: absolute;
     left: 2px;
@@ -696,15 +680,13 @@ input[type="checkbox"] {
     border-radius: 50%;
     background-color: white;
     transition: transform 0.3s;
-  }
-  
-  input[type="checkbox"]:checked {
+}
+#settings-modal input[type="checkbox"]:checked {
     background-color: var(--primary-color);
-  }
-  
-  input[type="checkbox"]:checked:after {
+}
+#settings-modal input[type="checkbox"]:checked:after {
     transform: translateX(20px);
-  }
+}
 
 @media(max-width: 1400px) {
     #header-title {

--- a/public/index.html
+++ b/public/index.html
@@ -8,6 +8,7 @@
     <link rel="alternate icon" type="image/png" href="Assets/dumbpad.png">
     <link rel="apple-touch-icon" href="Assets/dumbpad.png">
     <link rel="stylesheet" href="Assets/styles.css">
+    <link rel="stylesheet" href="Assets/preview-styles.css">
     <link rel="manifest" href="Assets/manifest.json">
     <script>
         (function() { // Initialize theme immediately - Prevents theme flicker
@@ -24,10 +25,19 @@
     <div class="container">
         <header>
             <div class="header-top">
-                <div id="header-title">
+                <div id="header-title" data-tooltip="Loading version...">
                     <h1 style="font-size: 1.5rem;">DumbPad</h1>
                 </div>
                 <div class="header-right"> 
+
+                    <button id="copy-link" class="icon-button" data-tooltip="Copy Link">
+                        <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                            <path stroke="none" d="M0 0h24v24H0z" fill="none"/>
+                            <path d="M9 15l6 -6" />
+                            <path d="M11 6l.463 -.536a5 5 0 0 1 7.071 7.072l-.534 .464" />
+                            <path d="M13 18l-.397 .534a5.068 5.068 0 0 1 -7.127 0a4.972 4.972 0 0 1 0 -7.071l.524 -.463" />
+                        </svg>
+                    </button>
                     <button id="search-open" class="icon-button" data-tooltip="Search ({shortcut})" data-shortcuts='{"win": "ctrl+k", "mac": "cmd+k"}'>
                         <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
                             <path stroke="none" d="M0 0h24v24H0z" fill="none"/><path d="M10 10m-7 0a7 7 0 1 0 14 0a7 7 0 1 0 -14 0" /><path d="M21 21l-6 -6" />
@@ -177,6 +187,10 @@
                     <label class="settings-label">
                         Markdown preview as default view:
                         <input type="checkbox" id="settings-default-markdown-preview" />
+                    </label>
+                    <label class="settings-label">
+                        Disable auto-expand markdown in print:
+                        <input type="checkbox" id="settings-disable-print-expand" />
                     </label>
                 </div>
                 <div class="modal-buttons">

--- a/public/managers/collaboration.js
+++ b/public/managers/collaboration.js
@@ -2,7 +2,7 @@ import { marked } from '/js/marked/marked.esm.js';
 
 export class CollaborationManager {
     constructor({ userId, userColor, currentNotepadId, operationsManager, editor, onNotepadChange, onUserDisconnect, onCursorUpdate,
-            settingsManager, toaster, confirmationManager, saveNotes, renameNotepad
+            settingsManager, toaster, confirmationManager, saveNotes, renameNotepad, addCopyButtonsToCodeBlocks
         })
     {
         this.userId = userId;
@@ -20,6 +20,7 @@ export class CollaborationManager {
         this.confirmationManager = confirmationManager;
         this.saveNotes = saveNotes;
         this.renameNotepad = renameNotepad;
+        this.addCopyButtonsToCodeBlocks = addCopyButtonsToCodeBlocks;
 
         this.ws = null;
         this.isReceivingUpdate = false;
@@ -198,6 +199,11 @@ export class CollaborationManager {
             
             // Update the preview pane in markdown
             this.previewPane.innerHTML = marked.parse(this.editor.value);
+            
+            // Add copy buttons to code blocks if callback is available
+            if (this.addCopyButtonsToCodeBlocks) {
+                this.addCopyButtonsToCodeBlocks();
+            }
 
             // Adjust cursor position based on operation type and position
             let newPos = currentPos;

--- a/public/managers/settings.js
+++ b/public/managers/settings.js
@@ -6,6 +6,7 @@ export default class SettingsManager {
     this.settingsInputAutoSaveStatusInterval = document.getElementById('autosave-status-interval-input');
     this.settingsEnableRemoteConnectionMessages = document.getElementById('settings-remote-connection-messages');
     this.settingsDefaultMarkdownPreview = document.getElementById('settings-default-markdown-preview');
+    this.settingsDisablePrintExpand = document.getElementById('settings-disable-print-expand');
   }
   
   defaultSettings() {
@@ -13,6 +14,7 @@ export default class SettingsManager {
       saveStatusMessageInterval: 500,
       enableRemoteConnectionMessages: false,
       defaultMarkdownPreview: false,
+      disablePrintExpand: false,
     }
   }
 
@@ -58,6 +60,9 @@ export default class SettingsManager {
 
       appSettings.defaultMarkdownPreview = currentSettings.defaultMarkdownPreview;
       this.settingsDefaultMarkdownPreview.checked = currentSettings.defaultMarkdownPreview;
+
+      appSettings.disablePrintExpand = currentSettings.disablePrintExpand;
+      this.settingsDisablePrintExpand.checked = currentSettings.disablePrintExpand;
       
       return currentSettings;
     }
@@ -77,6 +82,8 @@ export default class SettingsManager {
     appSettings.enableRemoteConnectionMessages = this.settingsEnableRemoteConnectionMessages.checked;
 
     appSettings.defaultMarkdownPreview = this.settingsDefaultMarkdownPreview.checked;
+
+    appSettings.disablePrintExpand = this.settingsDisablePrintExpand.checked;
     
     return appSettings;
   }

--- a/public/service-worker.js
+++ b/public/service-worker.js
@@ -1,32 +1,154 @@
-const CACHE_NAME = "DUMBPAD_PWA_CACHE_V1";
-const ASSETS_TO_CACHE = [];
+let APP_VERSION = "1.0.0"; // Default version, will be updated by server
 
-const preload = async () => {
-  console.log("Installing web app");
-  return await caches.open(CACHE_NAME)
-    .then(async (cache) => {
-      console.log("caching index and important routes");
-      const response = await fetch("/asset-manifest.json");
-      const assets = await response.json();
-      ASSETS_TO_CACHE.push(...assets, "/js/marked/marked.esm.js");
-      console.log("Assets Cached:", ASSETS_TO_CACHE);
-      return cache.addAll(ASSETS_TO_CACHE);
-  });
-}
+const getCacheName = (version) => `DUMBPAD_CACHE_${version}`;
 
-// Fetch asset manifest dynamically
-globalThis.addEventListener("install", (event) => {
-  event.waitUntil(preload());
+const getAppVersion = async () => {
+  try {
+    const response = await fetch("/api/config");
+    const data = await response.json();
+    return data.version;
+  } catch (error) {
+    console.error("Failed to fetch app version:", error);
+    return "1.0.0"; // Fallback version
+  }
+};
+
+const getCurrentCacheVersion = async () => {
+  const cacheNames = await caches.keys();
+  const dumbpadCaches = cacheNames.filter(name => name.startsWith('DUMBPAD_CACHE_') || name.startsWith('DUMBPAD_PWA_CACHE'));
+  
+  if (dumbpadCaches.length === 0) {
+    return null; // No cache exists
+  }
+  
+  // Extract version from cache name (e.g., "DUMBPAD_CACHE_1.0.1" -> "1.0.1")
+  const latestCache = dumbpadCaches[dumbpadCaches.length - 1];
+  return latestCache.replace('DUMBPAD_CACHE_', '');
+};
+
+const installNewCache = async (version) => {
+  const cacheName = getCacheName(version);
+  console.log("Installing new cache:", cacheName);
+  
+  const cache = await caches.open(cacheName);
+  
+  try {
+    const response = await fetch("/asset-manifest.json");
+    const assets = await response.json();
+    const assetsToCache = [...assets, "/js/marked/marked.esm.js", "/js/marked-extended-tables/index.js", "/js/marked-alert/index.js"];
+    
+    console.log("Assets to cache:", assetsToCache);
+    await cache.addAll(assetsToCache);
+    console.log("Cache installation complete for version:", version);
+  } catch (error) {
+    console.error("Failed to install cache:", error);
+    throw error;
+  }
+};
+
+const cleanupOldCaches = async (currentVersion) => {
+  const currentCacheName = getCacheName(currentVersion);
+  console.log("Cleaning up old caches, keeping current cache:", currentCacheName);
+
+  const cacheNames = await caches.keys();
+  const deletePromises = cacheNames
+    .filter(name => (name.startsWith('DUMBPAD_CACHE_') || name.startsWith('DUMBPAD_PWA_CACHE')) && name !== currentCacheName)
+    .map(name => {
+      console.log("Deleting old cache:", name);
+      return caches.delete(name);
+    });
+
+  return Promise.all(deletePromises);
+};
+
+const checkAndUpdateCache = async () => {
+  console.log("Checking cache version...");
+  
+  const appVersion = await getAppVersion();
+  const cacheVersion = await getCurrentCacheVersion();
+  
+  console.log("App version:", appVersion);
+  console.log("Cache version:", cacheVersion);
+  
+  if (!cacheVersion) {
+    // First time installation
+    console.log("First time installation - installing cache");
+    await installNewCache(appVersion);
+    return { updated: true, firstInstall: true };
+  }
+  
+  if (cacheVersion !== appVersion) {
+    // Version mismatch - update cache
+    console.log("Version mismatch - updating cache");
+    await installNewCache(appVersion);
+    await cleanupOldCaches(appVersion);
+    return { updated: true, firstInstall: false };
+  }
+  
+  console.log("Cache up to date");
+  return { updated: false, firstInstall: false };
+};
+
+self.addEventListener("install", (event) => {
+  console.log("Service worker installing...");
+  // Force the waiting service worker to become the active service worker
+  self.skipWaiting();
 });
 
-globalThis.addEventListener("activate", (event) => {
-  event.waitUntil(clients.claim());
+self.addEventListener("activate", (event) => {
+  console.log("Service worker activating...");
+  
+  event.waitUntil(
+    checkAndUpdateCache().then(({ updated, firstInstall }) => {
+      // Take control of all clients immediately
+      return self.clients.claim().then(() => {
+        if (updated && !firstInstall) {
+          // Cache was updated and it's not the first install - reload page
+          console.log("Cache updated - notifying clients to reload");
+          self.clients.matchAll().then(clients => {
+            clients.forEach(client => {
+              client.postMessage({ 
+                type: 'CACHE_UPDATED', 
+                reload: true,
+                version: APP_VERSION
+              });
+            });
+          });
+        } else if (updated && firstInstall) {
+          // First install - just notify, don't reload
+          console.log("Cache installed for first time");
+          self.clients.matchAll().then(clients => {
+            clients.forEach(client => {
+              client.postMessage({ 
+                type: 'CACHE_INSTALLED', 
+                reload: false,
+                version: APP_VERSION
+              });
+            });
+          });
+        }
+      });
+    })
+  );
 });
 
-globalThis.addEventListener("fetch", (event) => {
+self.addEventListener("fetch", (event) => {
   event.respondWith(
     caches.match(event.request).then((cachedResponse) => {
       return cachedResponse || fetch(event.request);
     })
   );
+});
+
+// Handle version check requests from the main thread
+self.addEventListener("message", (event) => {
+  if (event.data && event.data.type === 'CHECK_VERSION') {
+    checkAndUpdateCache().then(({ updated, firstInstall }) => {
+      event.ports[0].postMessage({
+        updated,
+        firstInstall,
+        version: APP_VERSION
+      });
+    });
+  }
 });


### PR DESCRIPTION
## Pull Request Overview

This PR enhances navigation via query parameters with history support, upgrades markdown preview and print styling (including auto-expand with a toggle setting), and implements dynamic service worker versioning with cache busting.

- Introduces dynamic SW versioning: reads version from `package.json`, injects into `/service-worker.js`, and exposes it in `/api/config`
- Adds query param support (`?id=`) for notepad selection, unique name generation on both client and server, and a “copy link” feature
- Revamps markdown preview styles (`preview-styles.css`), print preview behavior (auto-expanding `<details>` with a new setting), and code‐block copy buttons

<details>
<summary>Show a summary per file</summary>

| File                         | Description                                                        |
| ---------------------------- | ------------------------------------------------------------------ |
| server.js                    | Dynamic SW version, `/api/config` includes `version`, unique-name helper, unique naming in POST/PUT |
| public/service-worker.js     | Cache versioning logic: install/update/cleanup caches, SW messaging |
| public/managers/settings.js  | Adds `disablePrintExpand` setting field, persists default and load |
| public/managers/collaboration.js | Passes `addCopyButtonsToCodeBlocks` callback to update previews |
| public/index.html            | Loads `preview-styles.css`, adds copy-link button and version tooltip |
| public/app.js                | Implements query-param handling, URL updates, SW registration/updates, code-block copy buttons, print styling |
| public/Assets/styles.css     | Scopes checkbox styles to settings modal                           |
| public/Assets/preview-styles.css | New dedicated markdown preview stylesheet                      |
| package.json                 | Bumps to v1.0.1, adds `marked-alert` and `marked-extended-tables` deps |
| .github/copilot-instructions.md | New project principles and conventions doc                    |
| .cursorrules                 | Updates header-doc rules for backend/frontend/scripts             |
</details>


## Previews

| Feature | Description | Preview |
|---|---|---|
| Query Params with History | Query parameters are now used for browser back and forward functionality, improving navigation. | ![query-params](https://github.com/user-attachments/assets/dccd1e61-3914-471b-8a24-4f07df0a6c5c) |
| Print Preview (Light/Dark Mode) | The print preview accurately reflects the light/dark mode and styling of the notepad in Markdown. | ![print-preview-light](https://github.com/user-attachments/assets/ff0216db-af66-477a-bf12-093a747ab957) ![print-preview-dark](https://github.com/user-attachments/assets/98a91f7c-b4c7-4358-a56a-3b5fee3e6abb) |
| Print Preview Defaults to Expand Collapsed Sections | Print preview now defaults to expanding collapsed sections in Markdown. A new setting is available to disable this behavior. | ![setting-disable-expand](https://github.com/user-attachments/assets/89c87514-0903-4b75-ba12-73a54bc73ab0) |
| New Markdown Stylings | Added new Markdown stylings for alerts, details/collapse sections, and tables, along with revamped spacing. | ![markdown-preview1](https://github.com/user-attachments/assets/a17093ea-c357-454f-b0d3-c6f6491c1fce) ![markdown-preview2](https://github.com/user-attachments/assets/e06141e6-82d6-48cb-953f-e1cbc60a1dfd) |
- also added new service worker versioning with cache busting (still requires clearing cache for the new change but should auto reload moving forward)

<details>
<summary>Commits details:</summary>

- new service worker auto cache busting logic
- update markdown preview styles with fixes
- minor bug fixes

cleanup old caches on first install for backwards compatibility

include old cache name for busting

Adjust codeblock styles with new copy button

Add marked-alert and revamp of markdown styles

updating print preview styles to be a 1 to 1 style copy of the actual preview

Implement unique notepad naming & query params for ?id= with either notepad id or notepadname.
- also include window.history for back and forward capabilities

Add copy link to clipboard button in header-right

Add logic to auto expand collapsed details in print preview.
- also add new setting to disable that functionality
- update svg alert colors to match respectively

Make sure to get the updated settings for disabling expand markdown in print

update marked-alert cache name
</details>