### PR TITLE
Feat/add split preview

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dumbpad",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dumbpad",
-      "version": "1.0.3",
+      "version": "1.0.4",
       "dependencies": {
         "@highlightjs/cdn-assets": "^11.11.1",
         "cookie-parser": "^1.4.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dumbpad",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "A simple notepad application",
   "main": "server.js",
   "scripts": {

--- a/public/Assets/styles.css
+++ b/public/Assets/styles.css
@@ -185,6 +185,85 @@ main {
     position: relative;
     z-index: 1;
     background-color: var(--textarea-bg);
+    transition: var(--transition);
+}
+
+/* Split view wrapper */
+.editor-preview-wrapper {
+    display: flex;
+    height: calc(100vh - 9rem);
+    gap: 0;
+    position: relative;
+}
+
+/* Split view styles */
+.editor-preview-wrapper.split-view .editor-container {
+    width: 50%;
+    border-top-right-radius: 0;
+    border-bottom-right-radius: 0;
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.2), 2px 0 4px rgba(0, 0, 0, 0.1);
+}
+
+.editor-preview-wrapper.split-view .preview-container {
+    width: 50%;
+    border-top-left-radius: 0;
+    border-bottom-left-radius: 0;
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.2), -2px 0 4px rgba(0, 0, 0, 0.1);
+}
+
+.editor-preview-wrapper.preview-only .editor-container {
+    display: none;
+}
+
+.editor-preview-wrapper.preview-only .preview-container {
+    width: 100%;
+}
+
+.editor-preview-wrapper:not(.split-view):not(.preview-only) .editor-container {
+    width: 100%;
+}
+
+.editor-preview-wrapper:not(.split-view):not(.preview-only) .preview-container {
+    display: none;
+}
+
+/* Resize handle */
+.resize-handle {
+    width: 8px;
+    background-color: var(--secondary-color);
+    cursor: col-resize;
+    position: relative;
+    user-select: none;
+    transition: background-color 0.2s ease;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    z-index: 10;
+}
+
+.resize-handle:hover {
+    background-color: var(--primary-color);
+}
+
+.resize-handle-line {
+    width: 2px;
+    height: 40px;
+    background-color: var(--text-color);
+    opacity: 0.3;
+    border-radius: 2px;
+    transition: opacity 0.2s ease;
+}
+
+.resize-handle:hover .resize-handle-line {
+    opacity: 0.6;
+}
+
+/* Ensure proper flex behavior in split view */
+.editor-preview-wrapper.split-view .editor-container,
+.editor-preview-wrapper.split-view .preview-container {
+    flex-shrink: 0;
+    min-width: 200px;
+    max-width: calc(100% - 200px - 8px);
 }
 
 .toast-container {
@@ -797,6 +876,11 @@ main {
         margin: 0, auto;
         padding: 0, auto;
     }
+    
+    .editor-preview-wrapper {
+        height: 71vh;
+    }
+    
     #editor {
         padding: 0.3rem;
     }

--- a/public/Assets/styles.css
+++ b/public/Assets/styles.css
@@ -231,7 +231,7 @@ main {
 .resize-handle {
     width: 8px;
     background-color: var(--secondary-color);
-    cursor: col-resize;
+    cursor: ew-resize;
     position: relative;
     user-select: none;
     transition: background-color 0.2s ease;
@@ -239,7 +239,6 @@ main {
     align-items: center;
     justify-content: center;
     z-index: 10;
-    cursor: ew-resize;
 }
 
 .resize-handle:hover {

--- a/public/Assets/styles.css
+++ b/public/Assets/styles.css
@@ -229,16 +229,17 @@ main {
 
 /* Resize handle */
 .resize-handle {
-    width: 8px;
+    width: 6px;
     background-color: var(--secondary-color);
     cursor: ew-resize;
     position: relative;
     user-select: none;
+    touch-action: none; /* Prevent default touch behaviors */
     transition: background-color 0.2s ease;
     display: flex;
     align-items: center;
     justify-content: center;
-    z-index: 10;
+    z-index: 11;
 }
 
 .resize-handle:hover {
@@ -246,7 +247,7 @@ main {
 }
 
 .resize-handle-line {
-    width: 2px;
+    width: 4px;
     height: 40px;
     background-color: var(--text-color);
     opacity: 0.3;
@@ -910,6 +911,37 @@ main {
     
     .editor-preview-wrapper {
         height: 71vh;
+        flex-direction: column; /* Stack vertically on mobile */
+    }
+    
+    /* Mobile split view layout */
+    .editor-preview-wrapper.split-view {
+        flex-direction: column;
+    }
+    
+    .editor-preview-wrapper.split-view .editor-container,
+    .editor-preview-wrapper.split-view .preview-container {
+        width: 100% !important;
+        min-width: unset;
+        max-width: unset;
+        height: calc(50% - 10px); /* Split height equally, accounting for handle */
+        border-radius: 12px; /* Restore border radius on mobile */
+    }
+    
+    .editor-preview-wrapper.split-view .resize-handle {
+        width: 100%;
+        height: 8px;
+        cursor: row-resize;
+    }
+    
+    .editor-preview-wrapper.split-view .resize-handle-line {
+        width: 40px;
+        height: 2px;
+    }
+    
+    .editor-preview-wrapper.split-view .resize-handle:hover .resize-handle-line {
+        opacity: 0.6;
+        height: 4px;
     }
     
     #editor {

--- a/public/Assets/styles.css
+++ b/public/Assets/styles.css
@@ -239,6 +239,7 @@ main {
     align-items: center;
     justify-content: center;
     z-index: 10;
+    cursor: ew-resize;
 }
 
 .resize-handle:hover {
@@ -256,6 +257,7 @@ main {
 
 .resize-handle:hover .resize-handle-line {
     opacity: 0.6;
+    width: 6px;
 }
 
 /* Ensure proper flex behavior in split view */

--- a/public/Assets/styles.css
+++ b/public/Assets/styles.css
@@ -767,6 +767,36 @@ main {
     transform: translateX(20px);
 }
 
+#settings-modal input[type="radio"] {
+    appearance: none;
+    -webkit-appearance: none;
+    width: 18px;
+    height: 18px;
+    border: 2px solid var(--secondary-color);
+    border-radius: 50%;
+    background-color: var(--textarea-bg);
+    cursor: pointer;
+    transition: all 0.3s ease;
+    position: relative;
+}
+
+#settings-modal input[type="radio"]:checked {
+    border-color: var(--primary-color);
+    background-color: var(--primary-color);
+}
+
+#settings-modal input[type="radio"]:checked::after {
+    content: "";
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+    background-color: white;
+}
+
 @media(max-width: 1400px) {
     #header-title {
         font-size: 1.2rem;

--- a/public/app.js
+++ b/public/app.js
@@ -1089,7 +1089,6 @@ document.addEventListener('DOMContentLoaded', async () => {
         printNotepadBtn.addEventListener('click', () => {
             printNotepad();
         });
-        previewMarkdownBtn.addEventListener('click', () => previewManager.toggleMarkdownPreview(true));
 
         settingsButton.addEventListener('click', () => {
             settingsManager.loadSettings();
@@ -1368,6 +1367,7 @@ document.addEventListener('DOMContentLoaded', async () => {
         addShortcutEventListeners();
         addBrowserNavigationListener();
         searchManager.addEventListeners();
+        previewManager.addEventListeners();
     }
 
     function detectOS() {
@@ -1421,7 +1421,9 @@ document.addEventListener('DOMContentLoaded', async () => {
     }
     
     function applySettings(currentSettings) {
-        previewManager.toggleMarkdownPreview(false, currentSettings.defaultMarkdownPreview, false);
+        // Convert boolean setting to preview mode string
+        const previewMode = currentSettings.defaultMarkdownPreview ? 'preview-only' : 'off';
+        previewManager.toggleMarkdownPreview(false, previewMode, false);
     };
 
     // Initialize the app

--- a/public/app.js
+++ b/public/app.js
@@ -1421,8 +1421,8 @@ document.addEventListener('DOMContentLoaded', async () => {
     }
     
     function applySettings(currentSettings) {
-        // Convert boolean setting to preview mode string
-        const previewMode = currentSettings.defaultMarkdownPreview ? 'preview-only' : 'off';
+        // Use the new preview mode setting directly
+        const previewMode = currentSettings.defaultMarkdownPreviewMode || 'off';
         previewManager.toggleMarkdownPreview(false, previewMode, false);
     };
 

--- a/public/index.html
+++ b/public/index.html
@@ -190,8 +190,21 @@
                         <input type="checkbox" id="settings-remote-connection-messages" />
                     </label>
                     <label class="settings-label">
-                        Markdown preview as default view:
-                        <input type="checkbox" id="settings-default-markdown-preview" />
+                        Default preview mode:
+                        <div style="margin-top: 0.5rem; display: flex; gap: 1rem;">
+                            <label style="display: flex; align-items: center; gap: 0.5rem;">
+                                <input type="radio" name="default-preview-mode" id="settings-default-preview-editor" value="off" />
+                                Editor
+                            </label>
+                            <label style="display: flex; align-items: center; gap: 0.5rem;">
+                                <input type="radio" name="default-preview-mode" id="settings-default-preview-split" value="split" />
+                                Split
+                            </label>
+                            <label style="display: flex; align-items: center; gap: 0.5rem;">
+                                <input type="radio" name="default-preview-mode" id="settings-default-preview-full" value="preview-only" />
+                                Full
+                            </label>
+                        </div>
                     </label>
                     <label class="settings-label">
                         Disable auto-expand markdown in print:

--- a/public/index.html
+++ b/public/index.html
@@ -125,11 +125,16 @@
             </div>
         </header>
         <main>
-            <div id="editor-container" class="editor-container">
-                <textarea id="editor" placeholder="Start typing your notes here..." spellcheck="true" autofocus></textarea>
-            </div>
-            <div id="preview-container" class="preview-container" style="display: none;">
-                <div id="preview-pane"></div>
+            <div id="editor-preview-wrapper" class="editor-preview-wrapper">
+                <div id="editor-container" class="editor-container">
+                    <textarea id="editor" placeholder="Start typing your notes here..." spellcheck="true" autofocus></textarea>
+                </div>
+                <div id="resize-handle" class="resize-handle" style="display: none;">
+                    <div class="resize-handle-line"></div>
+                </div>
+                <div id="preview-container" class="preview-container" style="display: none;">
+                    <div id="preview-pane"></div>
+                </div>
             </div>
         </main>
         <div id="toast-container" class="toast-container"></div>

--- a/public/managers/preview.js
+++ b/public/managers/preview.js
@@ -1,9 +1,10 @@
 /**
  * PreviewManager handles all markdown preview functionality including:
- * - Toggling between edit and preview modes
+ * - Toggling between edit, split, and preview modes
  * - Rendering markdown content
  * - Managing preview styles and state
  * - Adding copy buttons to code blocks
+ * - Handling resizable split view
  */
 export class PreviewManager {
     constructor({
@@ -25,22 +26,128 @@ export class PreviewManager {
         this.collaborationManager = collaborationManager;
         this.marked = marked;
         
-        this.isPreviewMode = false;
+        // Preview modes: 'off', 'split', 'preview-only'
+        this.previewMode = 'off';
         this.DEBUG = false;
+        
+        // Get the wrapper element for split view
+        this.editorPreviewWrapper = document.getElementById('editor-preview-wrapper');
+        this.resizeHandle = document.getElementById('resize-handle');
+        
+        // Initialize resize functionality
+        this.initializeResize();
     }
 
     /**
      * Get current preview mode state
      */
     getPreviewMode() {
-        return this.isPreviewMode;
+        return this.previewMode;
     }
 
     /**
      * Set preview mode state
      */
     setPreviewMode(mode) {
-        this.isPreviewMode = mode;
+        this.previewMode = mode;
+    }
+
+    /**
+     * Check if preview is active (split or preview-only)
+     */
+    get isPreviewActive() {
+        return this.previewMode === 'split' || this.previewMode === 'preview-only';
+    }
+
+    /**
+     * Initialize resize handle functionality for split view
+     */
+    initializeResize() {
+        let isResizing = false;
+        let startX = 0;
+        let startY = 0;
+        let startEditorWidth = 0;
+        let startPreviewWidth = 0;
+        let startEditorHeight = 0;
+        let startPreviewHeight = 0;
+
+        const startResize = (e) => {
+            if (this.previewMode !== 'split') return;
+            
+            isResizing = true;
+            startX = e.clientX;
+            startY = e.clientY;
+            startEditorWidth = this.editorContainer.offsetWidth;
+            startPreviewWidth = this.previewContainer.offsetWidth;
+            startEditorHeight = this.editorContainer.offsetHeight;
+            startPreviewHeight = this.previewContainer.offsetHeight;
+            
+            document.addEventListener('mousemove', doResize);
+            document.addEventListener('mouseup', stopResize);
+            
+            // Check if we're in mobile layout (vertical split)
+            const isMobile = window.innerWidth <= 585;
+            document.body.style.cursor = isMobile ? 'row-resize' : 'col-resize';
+            document.body.style.userSelect = 'none';
+        };
+
+        const doResize = (e) => {
+            if (!isResizing) return;
+            
+            const isMobile = window.innerWidth <= 585;
+            
+            if (isMobile) {
+                // Vertical resizing for mobile
+                const deltaY = e.clientY - startY;
+                const wrapperHeight = this.editorPreviewWrapper.offsetHeight;
+                const handleHeight = this.resizeHandle.offsetHeight;
+                
+                const newEditorHeight = startEditorHeight + deltaY;
+                const newPreviewHeight = startPreviewHeight - deltaY;
+                
+                // Enforce minimum heights
+                const minHeight = 100;
+                const maxEditorHeight = wrapperHeight - minHeight - handleHeight;
+                const maxPreviewHeight = wrapperHeight - minHeight - handleHeight;
+                
+                if (newEditorHeight >= minHeight && newEditorHeight <= maxEditorHeight &&
+                    newPreviewHeight >= minHeight && newPreviewHeight <= maxPreviewHeight) {
+                    
+                    this.editorContainer.style.height = `${newEditorHeight}px`;
+                    this.previewContainer.style.height = `${newPreviewHeight}px`;
+                }
+            } else {
+                // Horizontal resizing for desktop
+                const deltaX = e.clientX - startX;
+                const wrapperWidth = this.editorPreviewWrapper.offsetWidth;
+                const handleWidth = this.resizeHandle.offsetWidth;
+                
+                const newEditorWidth = startEditorWidth + deltaX;
+                const newPreviewWidth = startPreviewWidth - deltaX;
+                
+                // Enforce minimum widths
+                const minWidth = 200;
+                const maxEditorWidth = wrapperWidth - minWidth - handleWidth;
+                const maxPreviewWidth = wrapperWidth - minWidth - handleWidth;
+                
+                if (newEditorWidth >= minWidth && newEditorWidth <= maxEditorWidth &&
+                    newPreviewWidth >= minWidth && newPreviewWidth <= maxPreviewWidth) {
+                    
+                    this.editorContainer.style.width = `${newEditorWidth}px`;
+                    this.previewContainer.style.width = `${newPreviewWidth}px`;
+                }
+            }
+        };
+
+        const stopResize = () => {
+            isResizing = false;
+            document.removeEventListener('mousemove', doResize);
+            document.removeEventListener('mouseup', stopResize);
+            document.body.style.cursor = '';
+            document.body.style.userSelect = '';
+        };
+
+        this.resizeHandle.addEventListener('mousedown', startResize);
     }
 
     /**
@@ -55,32 +162,97 @@ export class PreviewManager {
     }
 
     /**
-     * Toggle between edit and preview modes
+     * Toggle between edit, split, and preview modes (3-way cycle)
      */
     async toggleMarkdownPreview(toggle, enable, enableStatusMessage = true) {
         if (toggle) {
-            this.isPreviewMode = !this.isPreviewMode;
+            // Cycle through modes: off -> split -> preview-only -> off
+            switch (this.previewMode) {
+                case 'off':
+                    this.previewMode = 'split';
+                    break;
+                case 'split':
+                    this.previewMode = 'preview-only';
+                    break;
+                case 'preview-only':
+                    this.previewMode = 'off';
+                    break;
+                default:
+                    this.previewMode = 'off';
+            }
         } else {
-            this.isPreviewMode = enable;
+            // Direct mode setting for settings/initialization
+            if (typeof enable === 'string') {
+                this.previewMode = enable;
+            } else {
+                this.previewMode = enable ? 'preview-only' : 'off';
+            }
         }
         
-        if (this.isPreviewMode) {
-            this.inheritEditorStyles(this.previewPane);
-            await this.renderMarkdownPreview(this.editor.value);
-            this.previewContainer.style.display = 'block';
-            this.editorContainer.style.display = 'none';
-            this.previewMarkdownBtn.classList.add('active');
-            if (enableStatusMessage) {
-                this.toaster.show('Markdown Preview On', 'success');
-            }
-        } else {
-            this.previewContainer.style.display = 'none';
-            this.editorContainer.style.display = 'block';
-            this.previewMarkdownBtn.classList.remove('active');
-            this.editor.focus();
-            if (enableStatusMessage) {
-                this.toaster.show('Markdown Preview Off', 'error');
-            }
+        // Apply the layout based on current mode
+        await this.applyPreviewMode(enableStatusMessage);
+    }
+
+    /**
+     * Apply the current preview mode to the UI
+     */
+    async applyPreviewMode(enableStatusMessage = true) {
+        // Remove all mode classes
+        this.editorPreviewWrapper.classList.remove('split-view', 'preview-only');
+        
+        switch (this.previewMode) {
+            case 'split':
+                this.editorPreviewWrapper.classList.add('split-view');
+                this.previewContainer.style.display = 'block';
+                this.resizeHandle.style.display = 'flex';
+                this.previewMarkdownBtn.classList.add('active');
+                
+                this.inheritEditorStyles(this.previewPane);
+                await this.renderMarkdownPreview(this.editor.value);
+                
+                if (enableStatusMessage) {
+                    this.toaster.show('Split Preview On', 'success');
+                }
+                break;
+                
+            case 'preview-only':
+                this.editorPreviewWrapper.classList.add('preview-only');
+                this.previewContainer.style.display = 'block';
+                this.resizeHandle.style.display = 'none';
+                this.previewMarkdownBtn.classList.add('active');
+                
+                // Reset container dimensions
+                this.editorContainer.style.width = '';
+                this.previewContainer.style.width = '';
+                this.editorContainer.style.height = '';
+                this.previewContainer.style.height = '';
+                
+                this.inheritEditorStyles(this.previewPane);
+                await this.renderMarkdownPreview(this.editor.value);
+                
+                if (enableStatusMessage) {
+                    this.toaster.show('Full Preview On', 'success');
+                }
+                break;
+                
+            case 'off':
+            default:
+                this.previewContainer.style.display = 'none';
+                this.resizeHandle.style.display = 'none';
+                this.previewMarkdownBtn.classList.remove('active');
+                
+                // Reset container dimensions
+                this.editorContainer.style.width = '';
+                this.previewContainer.style.width = '';
+                this.editorContainer.style.height = '';
+                this.previewContainer.style.height = '';
+                
+                this.editor.focus();
+                
+                if (enableStatusMessage) {
+                    this.toaster.show('Editor On');
+                }
+                break;
         }
         
         this.collaborationManager.updateLocalCursor();
@@ -257,7 +429,7 @@ export class PreviewManager {
      * Update preview content if in preview mode
      */
     async updatePreviewIfActive(content) {
-        if (this.isPreviewMode) {
+        if (this.isPreviewActive) {
             await this.renderMarkdownPreview(content);
         }
     }
@@ -266,7 +438,7 @@ export class PreviewManager {
      * Generate formatted content for printing
      */
     getFormattedContentForPrint(content, isMarkdownFile) {
-        if (isMarkdownFile || this.isPreviewMode) {
+        if (isMarkdownFile || this.isPreviewActive) {
             return this.marked.parse(content);
         } else {
             return content
@@ -301,10 +473,10 @@ export class PreviewManager {
      */
     async preparePrintContent(content, notepadName, currentSettings, currentTheme) {
         const isMarkdownFile = notepadName.toLowerCase().endsWith('.md');
-        let formattedContent = this.getFormattedContentForPrint(content, isMarkdownFile || this.isPreviewMode);
+        let formattedContent = this.getFormattedContentForPrint(content, isMarkdownFile || this.isPreviewActive);
         
         // Add language labels to code blocks for print
-        if (isMarkdownFile || this.isPreviewMode) {
+        if (isMarkdownFile || this.isPreviewActive) {
             formattedContent = this.addCopyLangButtonsToCodeBlocks(formattedContent, true);
         }
         
@@ -551,6 +723,14 @@ export class PreviewManager {
     addEventListeners() {
         this.previewMarkdownBtn.addEventListener('click', () => {
             this.toggleMarkdownPreview(true);
+        });
+        
+        // Handle window resize to switch between mobile and desktop layouts
+        window.addEventListener('resize', () => {
+            if (this.previewMode === 'split') {
+                // Reapply split mode to adjust layout for current screen size
+                this.applyPreviewMode(false);
+            }
         });
     }
 }

--- a/public/managers/settings.js
+++ b/public/managers/settings.js
@@ -5,7 +5,9 @@ export default class SettingsManager {
     this.applySettings = applySettings
     this.settingsInputAutoSaveStatusInterval = document.getElementById('autosave-status-interval-input');
     this.settingsEnableRemoteConnectionMessages = document.getElementById('settings-remote-connection-messages');
-    this.settingsDefaultMarkdownPreview = document.getElementById('settings-default-markdown-preview');
+    this.settingsDefaultPreviewEditor = document.getElementById('settings-default-preview-editor');
+    this.settingsDefaultPreviewSplit = document.getElementById('settings-default-preview-split');
+    this.settingsDefaultPreviewFull = document.getElementById('settings-default-preview-full');
     this.settingsDisablePrintExpand = document.getElementById('settings-disable-print-expand');
   }
   
@@ -13,7 +15,7 @@ export default class SettingsManager {
     return { // Add additional default settings in here:
       saveStatusMessageInterval: 500,
       enableRemoteConnectionMessages: false,
-      defaultMarkdownPreview: false,
+      defaultMarkdownPreviewMode: 'off', // 'off', 'split', or 'preview-only'
       disablePrintExpand: false,
     }
   }
@@ -58,8 +60,19 @@ export default class SettingsManager {
       appSettings.enableRemoteConnectionMessages = currentSettings.enableRemoteConnectionMessages;
       this.settingsEnableRemoteConnectionMessages.checked = currentSettings.enableRemoteConnectionMessages;
 
-      appSettings.defaultMarkdownPreview = currentSettings.defaultMarkdownPreview;
-      this.settingsDefaultMarkdownPreview.checked = currentSettings.defaultMarkdownPreview;
+      appSettings.defaultMarkdownPreviewMode = currentSettings.defaultMarkdownPreviewMode || 'off';
+      // Set the appropriate radio button based on the saved setting
+      switch (currentSettings.defaultMarkdownPreviewMode) {
+        case 'split':
+          this.settingsDefaultPreviewSplit.checked = true;
+          break;
+        case 'preview-only':
+          this.settingsDefaultPreviewFull.checked = true;
+          break;
+        default:
+          this.settingsDefaultPreviewEditor.checked = true;
+          break;
+      }
 
       appSettings.disablePrintExpand = currentSettings.disablePrintExpand;
       this.settingsDisablePrintExpand.checked = currentSettings.disablePrintExpand;
@@ -81,7 +94,16 @@ export default class SettingsManager {
 
     appSettings.enableRemoteConnectionMessages = this.settingsEnableRemoteConnectionMessages.checked;
 
-    appSettings.defaultMarkdownPreview = this.settingsDefaultMarkdownPreview.checked;
+    // Get the selected radio button value for default preview mode
+    if (this.settingsDefaultPreviewEditor.checked) {
+      appSettings.defaultMarkdownPreviewMode = 'off';
+    } else if (this.settingsDefaultPreviewSplit.checked) {
+      appSettings.defaultMarkdownPreviewMode = 'split';
+    } else if (this.settingsDefaultPreviewFull.checked) {
+      appSettings.defaultMarkdownPreviewMode = 'preview-only';
+    } else {
+      appSettings.defaultMarkdownPreviewMode = 'off'; // fallback to default
+    }
 
     appSettings.disablePrintExpand = this.settingsDisablePrintExpand.checked;
     


### PR DESCRIPTION
## Pull Request Overview

Introduces a new split view for markdown preview alongside existing edit and full preview modes, adds a draggable resize handle, and updates settings to choose a default preview mode.

- Adds a 3-way toggle (off, split, full) for markdown preview cycling.
- Implements a draggable resize handle for split view.
- Updates settings UI to a radio group for selecting default preview mode.

| File                              | Description                                                                                                    |
|-----------------------------------|---------------------------------------------------------------------------------------------------------------|
| public/managers/settings.js       | Replaced default preview checkbox with three radio inputs and updated logic for storing/applying the default mode. |
| public/managers/preview.js        | Extended PreviewManager to track `'off'`, `'split'`, and `'preview-only'` modes, added resize handle support. |
| public/index.html                 | Wrapped editor and preview in a flex container, inserted the resize handle, and converted settings to radio buttons. |
| public/app.js                     | Updated initialization to use the new default mode setting and delegated event listeners to PreviewManager.   |
| public/Assets/styles.css          | Added CSS rules for split and preview-only layouts, styled the resize handle, and ensured responsive sizing.   |
| package.json                      | Bumped application version from 1.0.3 to 1.0.4.                                                               |


<img width=50% src="https://github.com/user-attachments/assets/9aab96fb-12e8-42d7-bebd-ba1689ca2035" />

<img width=50% src="https://github.com/user-attachments/assets/a56b098f-afec-4bc6-93c2-c4e311eb58c7" />
