### PR TITLE
Fix preview styles on light/dark toggle and marked-alerts fix

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -1206,7 +1206,7 @@ document.addEventListener('DOMContentLoaded', async () => {
             currentTheme = currentTheme === 'dark' ? 'light' : 'dark';
             document.documentElement.setAttribute('data-theme', currentTheme);
             previewManager.updateHighlightTheme(currentTheme);
-            previewManager.inheritEditorStyles(previewManager.previewPane);
+            previewManager.updatePreviewStyles();
             storageManager.save(THEME_KEY, currentTheme);
         });
     }
@@ -1460,6 +1460,8 @@ document.addEventListener('DOMContentLoaded', async () => {
             });
         
         applySettings(appSettings);
+        previewManager.updatePreviewStyles();
+        previewManager.updateHighlightTheme(currentTheme);
         await registerServiceWorker();
     };
 


### PR DESCRIPTION
- Fix to reapply styles to markdown preview on light/darkmode toggle and on load
- correct `marked-alert` usage in marked