### PR TITLE
Refine .dockerignore to exclude dev and config files

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -4,11 +4,12 @@ data
 .cursorrules
 .dockerignore
 .git
+.github
 .gitignore
+.gitattributes
 docs
 Dockerfile
 docker-compose.yml
 README.md
 .env
 .env.*
-!.env.example


### PR DESCRIPTION
Add `.github` and `.gitattributes` to the ignore list as they are not required in the Docker image. Remove the explicit inclusion of `!.env.example`, so it is now ignored by the `.env.*` rule, preventing example configuration from being bundled. I understand its also not needed. That comes from this comment: https://github.com/DumbWareio/DumbPad/pull/75#issuecomment-3240313871 .

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized Docker build context by ignoring .github and .gitattributes, reducing transferred files and speeding up builds.
  * Updated ignore rules so example environment files are excluded from Docker builds, helping keep images leaner and build steps cleaner.
  * No changes to app features or behavior; end-user experience remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->